### PR TITLE
feat: add MFEs to transifex.yml

### DIFF
--- a/transifex.yml
+++ b/transifex.yml
@@ -1,13 +1,122 @@
 git:
   filters:
+  
+  # credentials
   - filter_type: dir
     file_format: PO
     source_file_extension: po
     source_language: en
     source_file_dir: credentials/credentials/conf/locale/en/
     translation_files_expression: 'credentials/credentials/conf/locale/<lang>/'
+  
+  # frontend-app-account
   - filter_type: file
     file_format: KEYVALUEJSON
     source_language: en
     source_file: frontend-app-account/src/i18n/transifex_input.json
     translation_files_expression: 'frontend-app-account/src/i18n/messages/<lang>.json'
+  
+  # frontend-app-authn   
+  - filter_type: file
+    file_format: KEYVALUEJSON
+    source_language: en
+    source_file: frontend-app-authn/src/i18n/transifex_input.json
+    translation_files_expression: 'frontend-app-authn/src/i18n/messages/<lang>.json'
+  
+  # frontend-app-course-authoring
+  - filter_type: file
+    file_format: KEYVALUEJSON
+    source_language: en
+    source_file: frontend-app-course-authoring/src/i18n/transifex_input.json
+    translation_files_expression: 'frontend-app-course-authoring/src/i18n/messages/<lang>.json'
+  
+  # frontend-app-discussions
+  - filter_type: file
+    file_format: KEYVALUEJSON
+    source_language: en
+    source_file: frontend-app-discussions/src/i18n/transifex_input.json
+    translation_files_expression: 'frontend-app-discussions/src/i18n/messages/<lang>.json'
+  
+  # frontend-app-ecommerce
+  - filter_type: file
+    file_format: KEYVALUEJSON
+    source_language: en
+    source_file: frontend-app-ecommerce/src/i18n/transifex_input.json
+    translation_files_expression: 'frontend-app-ecommerce/src/i18n/messages/<lang>.json'
+  
+  # frontend-app-enterprise-public-catalog
+  - filter_type: file
+    file_format: KEYVALUEJSON
+    source_language: en
+    source_file: frontend-app-enterprise-public-catalog/src/i18n/transifex_input.json
+    translation_files_expression: 'frontend-app-enterprise-public-catalog/src/i18n/messages/<lang>.json'
+  
+  # frontend-app-gradebook
+  - filter_type: file
+    file_format: KEYVALUEJSON
+    source_language: en
+    source_file: frontend-app-gradebook/src/i18n/transifex_input.json
+    translation_files_expression: 'frontend-app-gradebook/src/i18n/messages/<lang>.json'
+  
+  # frontend-app-learner-record
+  - filter_type: file
+    file_format: KEYVALUEJSON
+    source_language: en
+    source_file: frontend-app-learner-record/src/i18n/transifex_input.json
+    translation_files_expression: 'frontend-app-learner-record/src/i18n/messages/<lang>.json'
+  
+  # frontend-app-learning
+  - filter_type: file
+    file_format: KEYVALUEJSON
+    source_language: en
+    source_file: frontend-app-learning/src/i18n/transifex_input.json
+    translation_files_expression: 'frontend-app-learning/src/i18n/messages/<lang>.json'
+  
+  # frontend-app-library-authoring
+  - filter_type: file
+    file_format: KEYVALUEJSON
+    source_language: en
+    source_file: frontend-app-library-authoring/src/i18n/transifex_input.json
+    translation_files_expression: 'frontend-app-library-authoring/src/i18n/messages/<lang>.json'
+  
+  # frontend-app-payment
+  - filter_type: file
+    file_format: KEYVALUEJSON
+    source_language: en
+    source_file: frontend-app-payment/src/i18n/transifex_input.json
+    translation_files_expression: 'frontend-app-payment/src/i18n/messages/<lang>.json'
+    
+  # frontend-app-profile
+  - filter_type: file
+    file_format: KEYVALUEJSON
+    source_language: en
+    source_file: frontend-app-profile/src/i18n/transifex_input.json
+    translation_files_expression: 'frontend-app-profile/src/i18n/messages/<lang>.json'
+    
+  # frontend-app-program-console
+  - filter_type: file
+    file_format: KEYVALUEJSON
+    source_language: en
+    source_file: frontend-app-program-console/src/i18n/transifex_input.json
+    translation_files_expression: 'frontend-app-program-console/src/i18n/messages/<lang>.json'
+    
+  # frontend-app-support-tools
+  - filter_type: file
+    file_format: KEYVALUEJSON
+    source_language: en
+    source_file: frontend-app-support-tools/src/i18n/transifex_input.json
+    translation_files_expression: 'frontend-app-support-tools/src/i18n/messages/<lang>.json'
+    
+  # frontend-component-footer
+  - filter_type: file
+    file_format: KEYVALUEJSON
+    source_language: en
+    source_file: frontend-component-footer/src/i18n/transifex_input.json
+    translation_files_expression: 'frontend-component-footer/src/i18n/messages/<lang>.json'
+    
+  # frontend-component-header
+  - filter_type: file
+    file_format: KEYVALUEJSON
+    source_language: en
+    source_file: frontend-component-header/src/i18n/transifex_input.json
+    translation_files_expression: 'frontend-component-header/src/i18n/messages/<lang>.json'

--- a/transifex.yml
+++ b/transifex.yml
@@ -6,3 +6,8 @@ git:
     source_language: en
     source_file_dir: credentials/credentials/conf/locale/en/
     translation_files_expression: 'credentials/credentials/conf/locale/<lang>/'
+  - filter_type: file
+    file_format: JSON
+    source_language: en
+    source_file: frontend-app-account/src/i18n/transifex_input.json
+    translation_files_expression: 'frontend-app-account/src/i18n/messages/<lang>.json'

--- a/transifex.yml
+++ b/transifex.yml
@@ -7,7 +7,7 @@ git:
     source_file_dir: credentials/credentials/conf/locale/en/
     translation_files_expression: 'credentials/credentials/conf/locale/<lang>/'
   - filter_type: file
-    file_format: JSON
+    file_format: KEYVALUEJSON
     source_language: en
     source_file: frontend-app-account/src/i18n/transifex_input.json
     translation_files_expression: 'frontend-app-account/src/i18n/messages/<lang>.json'


### PR DESCRIPTION
Adds the configuration needed to automatically upload translation source files from MFEs to Transifex and to put them in the right place once translated.

The yaml was tested in the [Transifex project openedx-sandbox](https://www.transifex.com/open-edx/openedx-sandbox)

And its ability to download back into the right place was tested in https://github.com/openedx/openedx-translations/pull/20
