### PR TITLE
fix: continue extraction when a repo fails

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -41,6 +41,7 @@ jobs:
         repo:
           - credentials
     runs-on: ubuntu-latest
+    continue-on-error: true
     needs: [setup-branch]
 
     steps:
@@ -144,6 +145,7 @@ jobs:
           - frontend-app-gradebook
           - frontend-app-program-console
     runs-on: ubuntu-latest
+    continue-on-error: true
     needs: [setup-branch, python-translations]
     steps:
       # Clones the openedx-translations repo


### PR DESCRIPTION
by using `continue-on-error` (https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures), translation extraction on a single repo will not stop extraction from running on the rest of the repos