### PR TITLE
fix: exchange --auto for --admin

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -225,7 +225,7 @@ jobs:
           # This token requires Write access to the openedx-translations repo
           GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
         if: "${{ env.COMMIT_COUNT > 0 }}"
-        run: gh pr merge ${{ env.PR_URL }} --merge --auto
+        run: gh pr merge ${{ env.PR_URL }} --merge --admin
 
       # Notify that branch did not merge because there were no new commits in the branch
       - name: notify of empty branch


### PR DESCRIPTION
Many of the PRs generated by the edx-transifex-bot via the extract translation
workflow [are being inexplicably closed](https://github.com/openedx/openedx-translations/pulls?q=is%3Apr+is%3Aclosed+author%3Aedx-transifex-bot). By switching the flag from `--auto` to
`--admin`, I'm hoping to force the merging of the PR instead of leaving it to be
automatically merged.