### PR TITLE
feat: add python-based repos

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -39,7 +39,11 @@ jobs:
       max-parallel: 1
       matrix:
         repo:
+          - api-doc-tools
+          - blockstore
+          - course-discovery
           - credentials
+          - edx-enterprise
     runs-on: ubuntu-latest
     continue-on-error: true
     needs: [setup-branch]

--- a/transifex.yml
+++ b/transifex.yml
@@ -1,6 +1,30 @@
 git:
   filters:
 
+  # api-doc-tools
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/api-doc-tools/edx_api_doc_tools/conf/locale/en/
+    translation_files_expression: 'translations/api-doc-tools/edx_api_doc_tools/conf/locale/<lang>/'
+
+  # blockstore
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/blockstore/blockstore/conf/locale/en/
+    translation_files_expression: 'translations/blockstore/blockstore/conf/locale/<lang>/'
+
+  # course-discovery
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/course-discovery/course_discovery/conf/locale/en/
+    translation_files_expression: 'translations/course-discovery/course_discovery/conf/locale/<lang>/'
+
   # credentials
   - filter_type: dir
     file_format: PO
@@ -8,6 +32,14 @@ git:
     source_language: en
     source_file_dir: translations/credentials/credentials/conf/locale/en/
     translation_files_expression: 'translations/credentials/credentials/conf/locale/<lang>/'
+
+  # edx-enterprise
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/edx-enterprise/enterprise/conf/locale/en/
+    translation_files_expression: 'translations/edx-enterprise/enterprise/conf/locale/<lang>/'
 
   # frontend-app-account
   - filter_type: file


### PR DESCRIPTION
Python-based repos with correct configuration (api-doc-tools, blockstore,
course-discovery, and edx-enterprise) have been added to the workflow and
transifex.yml.