### PR TITLE
fix: remove always delete branch

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -230,11 +230,9 @@ jobs:
         run: gh pr merge ${{ env.PR_URL }} --merge --auto
 
       # Notify that branch did not merge because there were no new commits in the branch
-      - name: notify of empty branch
+      # and delete the branch now that it is unnecessary
+      - name: notify of empty branch and delete branch
         if: (steps.mergePR.outcome == 'skipped')
-        run: echo "The branch was not merged because the branch had 0 commits."
-
-      # Delete the branch
-      - name: delete branch
-        if: always()
-        run: git push origin -d ${{ needs.setup-branch.outputs.branch }}
+        run: |
+          echo "The branch was not merged because the branch had 0 commits."
+          git push origin -d ${{ needs.setup-branch.outputs.branch }}


### PR DESCRIPTION
Always deleting the branch whether it succeeds or fails was causing [the PR to not merge even if it was successful because the branch was deleted](https://github.com/openedx/openedx-translations/pulls?q=is%3Apr+is%3Aclosed+author%3Aedx-transifex-bot+is%3Aunmerged). Automatic branch deletion once it has been merged has been added to the repo's settings, and the deletion step has been absorbed by the previous notification step so that it only deletes branches without commits.