### PR TITLE
fix: remove "translations" from python commit msg

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -106,7 +106,7 @@ jobs:
         if: "${{ env.GIT_STATUS > 0 }}"
         run: |
           # commit the changes
-          git commit -m "chore: add extracted translation source files from translations/${{ matrix.repo }}"
+          git commit -m "chore: add extracted translation source files from ${{ matrix.repo }}"
           # push changes to branch
           git push
 


### PR DESCRIPTION
Noticed that the commit messages for the python translation job has an unnecessary "translation".