### PR TITLE
feat: Add frontend-lib-content-components

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -148,6 +148,7 @@ jobs:
           - frontend-app-support-tools
           - frontend-component-footer
           - frontend-component-header
+          - frontend-lib-content-components
           - paragon
           - studio-frontend
     runs-on: ubuntu-latest

--- a/transifex.yml
+++ b/transifex.yml
@@ -150,6 +150,13 @@ git:
     source_file: translations/frontend-component-header/src/i18n/transifex_input.json
     translation_files_expression: 'translations/frontend-component-header/src/i18n/messages/<lang>.json'
 
+  # frontend-lib-content-components
+  - filter_type: file
+    file_format: KEYVALUEJSON
+    source_language: en
+    source_file: translations/frontend-lib-content-components/src/i18n/transifex_input.json
+    translation_files_expression: 'translations/frontend-lib-content-components/src/i18n/messages/<lang>.json'
+
   # paragon
   - filter_type: file
     file_format: KEYVALUEJSON


### PR DESCRIPTION
The repository seems ready and the error message is from the message itself.

`make extract_translations` seems to be working properly.
The message below is not an error. It's a translation for the [FormattedMessage in the ErrorPage](https://github.com/openedx/frontend-lib-content-components/blob/61c99b9b4051f0269114555655b4e28ee71e41cf/src/editors/sharedComponents/ErrorBoundary/ErrorPage.jsx#L27-L47).
frontend-lib-content-components `$ cat src/i18n/transifex_input.json`
```
{
  "unexpected.error.message.text": "An unexpected error occurred. Please click the button below to refresh the page.",
  "unexpected.error.button.text": "Try again"
}
```

Proposal: OEP-0058 
Project: FC-0012


### TODO

 - [x] Test the workflow on my fork: https://github.com/Zeit-Labs/openedx-translations/actions/runs/4428707205/jobs/7768197
 - [x] Ready for review and merge