### PR TITLE
chore: standarize studio-frontend MFE i18n pattern

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -125,7 +125,6 @@ jobs:
         # * frontend-app-learner-portal-programs
         # * frontend-component-cookie-policy-banner
         # * frontend-app-programs-dashboard
-        # studio-frontend has a different file structure
         # repos with errors running extract_translations
         # * frontend-template-application
         repo:

--- a/transifex.yml
+++ b/transifex.yml
@@ -161,5 +161,5 @@ git:
   - filter_type: file
     file_format: KEYVALUEJSON
     source_language: en
-    source_file: translations/studio-frontend/src/data/i18n/default/transifex_input.json
-    translation_files_expression: 'translations/studio-frontend/src/data/i18n/locales/<lang>.json'
+    source_file: translations/studio-frontend/src/i18n/transifex_input.json
+    translation_files_expression: 'translations/studio-frontend/src/i18n/messages/<lang>.json'


### PR DESCRIPTION
Mostly path changes to ensure studio-frontend matches other repos i18n structure.

This PR needs https://github.com/openedx/studio-frontend/pull/374 before it's merged.

Refs: FC-0012 OEP-58