### PR TITLE
feat: add frontend-lib-special-exams

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -148,6 +148,7 @@ jobs:
           - frontend-component-footer
           - frontend-component-header
           - frontend-lib-content-components
+          - frontend-lib-special-exams
           - paragon
           - studio-frontend
     runs-on: ubuntu-latest

--- a/transifex.yml
+++ b/transifex.yml
@@ -157,6 +157,13 @@ git:
     source_file: translations/frontend-lib-content-components/src/i18n/transifex_input.json
     translation_files_expression: 'translations/frontend-lib-content-components/src/i18n/messages/<lang>.json'
 
+  # frontend-lib-special-exams
+  - filter_type: file
+    file_format: KEYVALUEJSON
+    source_language: en
+    source_file: translations/frontend-lib-special-exams/src/i18n/transifex_input.json
+    translation_files_expression: 'translations/frontend-lib-special-exams/src/i18n/messages/<lang>.json'
+
   # paragon
   - filter_type: file
     file_format: KEYVALUEJSON


### PR DESCRIPTION
The package newly included MFE Standard i18n pattern.

Tested on my fork: https://github.com/Zeit-Labs/openedx-translations/actions/runs/4428707205/jobs/7768197651
Needs: https://github.com/openedx/frontend-lib-special-exams/pull/85 before this can be merged

Refs: FC-0012 OEP-0058

 - [x] Ready for review and merge