### PR TITLE
feat: Add xblock-lti-consumer to the translation pipeline

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -44,6 +44,7 @@ jobs:
           - DoneXBlock
           - RecommenderXBlock
           - xblock-drag-and-drop-v2
+          - xblock-lti-consumer
     runs-on: ubuntu-latest
     continue-on-error: true
     needs: [setup-branch]

--- a/transifex.yml
+++ b/transifex.yml
@@ -201,3 +201,11 @@ git:
     source_language: en
     source_file_dir: translations/xblock-drag-and-drop-v2/drag_and_drop_v2/conf/locale/en/
     translation_files_expression: 'translations/xblock-drag-and-drop-v2/drag_and_drop_v2/conf/locale/<lang>/'
+
+  # xblock-lti-consumer
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/xblock-lti-consumer/lti_consumer/conf/locale/en/
+    translation_files_expression: 'translations/xblock-lti-consumer/lti_consumer/conf/locale/<lang>/'


### PR DESCRIPTION
feat: Add [xblock-lti-consumer](https://github.com/openedx/xblock-lti-consumer) to the translation pipeline

**IMPORTANT:** This PR needs https://github.com/openedx/xblock-lti-consumer/pull/341 before it's merged.

Refs:
This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
see details [here](https://github.com/openedx/xblock-lti-consumer/pull/341)