### PR TITLE
fix: automerge transifex PRs without --rebase

### DIFF
--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -24,4 +24,4 @@ jobs:
           # This token requires Write access to the openedx-translations repo
           GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
         if: "${{ github.actor == env.TRANSIFEX_APP_ACTOR_NAME && github.actor_id == env.TRANSIFEX_APP_ACTOR_ID }}"
-        run: gh pr merge ${{ github.head_ref }} --rebase --auto
+        run: gh pr merge ${{ github.head_ref }} --auto


### PR DESCRIPTION
The `--rebase` option could be causing race conditions.

It seems that `--rebase` is redaundant for the following reasons:

 - Each automatic Transifex pull request updates a single translation file.
 - The translations files are not touched, except by automatic Transifex PRs.
 - In the case of conflicts `--rebase` won't help because conflicts needs manual resolution.
 - When having two competing PRs due to, for example, timing issues closing them or merging one of them could result into stale translations which will be fixed in the next round of automatic PRs.

Refs: [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) implementing Translation Infrastructure OEP-58.
