### PR TITLE
feat: Add xblock-qualtrics-survey to the translation pipeline

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -45,6 +45,7 @@ jobs:
           - RecommenderXBlock
           - xblock-drag-and-drop-v2
           - xblock-lti-consumer
+          - xblock-qualtrics-survey
     runs-on: ubuntu-latest
     continue-on-error: true
     needs: [setup-branch]

--- a/transifex.yml
+++ b/transifex.yml
@@ -209,3 +209,11 @@ git:
     source_language: en
     source_file_dir: translations/xblock-lti-consumer/lti_consumer/conf/locale/en/
     translation_files_expression: 'translations/xblock-lti-consumer/lti_consumer/conf/locale/<lang>/'
+
+  # xblock-qualtrics-survey
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/xblock-qualtrics-survey/qualtricssurvey/conf/locale/en/
+    translation_files_expression: 'translations/xblock-qualtrics-survey/qualtricssurvey/conf/locale/<lang>/'


### PR DESCRIPTION
feat: Add [xblock-qualtrics-survey](https://github.com/openedx/xblock-qualtrics-survey) to the translation pipeline

**IMPORTANT:** This PR needs https://github.com/openedx/xblock-qualtrics-survey/pull/73 before it's merged.

- [x] Verified in a test PR in a forked repo: https://github.com/Zeit-Labs/openedx-translations/pull/11/files#r1168881902

Refs:
This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
see details [here](https://github.com/openedx/xblock-qualtrics-survey/pull/73)