### PR TITLE
fix: add required timeout to automerge retry

### DIFF
--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           retry_wait_seconds: 60
           max_attempts: 5
+          timeout_minutes: 15
           retry_on: error
           command: |
             gh pr merge ${{ github.head_ref }} --rebase --auto


### PR DESCRIPTION
The retry on the transifex automerge action was missing a required retry parameter. This updates the action to have the required timeout.