### PR TITLE
fix: include .po files even if they are ignored

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -98,7 +98,8 @@ jobs:
           # extract_translations into EN_DIR and adds them
           DJANGO_PATH=$(find $EN_DIR -name 'django.po')
           DJANGOJS_PATH=$(find $EN_DIR -name 'djangojs.po')
-          git add $DJANGO_PATH $DJANGOJS_PATH -v
+          # use (-f) to force add the files even if they are ignored in the source repo
+          git add $DJANGO_PATH $DJANGOJS_PATH -f -v
           # Check the git statuses of the translation source files
           echo "GIT_STATUS=$(git status $DJANGO_PATH $DJANGOJS_PATH -s | wc -l)" >> $GITHUB_ENV
 


### PR DESCRIPTION
fix: include `.po` files even if they are ignored

Some repos have `.po` files ignored in .gitignore. Adding `django.po` and `djangojs.po` will fail in the pipeline process because of that. We resolve the issue by forcing git to include these files even if they are ignored in the source repo

This bug was introduced while adding [xblock-submit-and-compare](https://github.com/openedx/xblock-submit-and-compare) to the translation pipeline. See https://github.com/openedx/openedx-translations/pull/201

Refs: FC-0012 OEP-58