### PR TITLE
feat: Add completion to the translation pipeline

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -39,6 +39,7 @@ jobs:
       max-parallel: 1
       matrix:
         repo:
+          - completion
           - course-discovery
           - credentials
           - DoneXBlock

--- a/transifex.yml
+++ b/transifex.yml
@@ -1,6 +1,14 @@
 git:
   filters:
 
+  # completion
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/completion/completion/conf/locale/en/
+    translation_files_expression: 'translations/completion/completion/conf/locale/<lang>/'
+
   # course-discovery
   - filter_type: dir
     file_format: PO


### PR DESCRIPTION
feat: Add [completion](https://github.com/openedx/completion) to the translation pipeline

**IMPORTANT:** This PR needs This PR needs https://github.com/openedx/completion/pull/232 before it's merged. before it's merged.

- [x] Verified in a test PR in a forked repo: https://github.com/Zeit-Labs/openedx-translations/pull/20/files#r1178088044

Refs:
This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
see details [here](https://github.com/openedx/xblock-submit-and-compare/pull/96)