### PR TITLE
feat: Add edx-ora2 to the translation pipeline

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -42,6 +42,7 @@ jobs:
           - course-discovery
           - credentials
           - DoneXBlock
+          - edx-ora2
           - RecommenderXBlock
           - xblock-drag-and-drop-v2
           - xblock-lti-consumer

--- a/transifex.yml
+++ b/transifex.yml
@@ -25,6 +25,14 @@ git:
     source_file_dir: translations/DoneXBlock/done/conf/locale/en/
     translation_files_expression: 'translations/DoneXBlock/done/conf/locale/<lang>/'
 
+  # edx-ora2
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/edx-ora2/openassessment/conf/locale/en/
+    translation_files_expression: 'translations/edx-ora2/openassessment/conf/locale/<lang>/'
+
   # frontend-app-account
   - filter_type: file
     file_format: KEYVALUEJSON


### PR DESCRIPTION
feat: Add [edx-ora2](https://github.com/openedx/edx-ora2) to the translation pipeline

**IMPORTANT:** This PR needs https://github.com/openedx/edx-ora2/pull/1932 before it's merged.

- [x] Verified in a test PR in a forked repo: https://github.com/Zeit-Labs/openedx-translations/pull/21/files#r1178971590

Refs:
This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
see details [here](https://github.com/openedx/xblock-submit-and-compare/pull/96)