### PR TITLE
feat: Add edx-proctoring to the translation pipeline

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -44,6 +44,7 @@ jobs:
           - credentials
           - DoneXBlock
           - edx-ora2
+          - edx-proctoring
           - RecommenderXBlock
           - xblock-drag-and-drop-v2
           - xblock-lti-consumer

--- a/transifex.yml
+++ b/transifex.yml
@@ -41,6 +41,15 @@ git:
     source_file_dir: translations/edx-ora2/openassessment/conf/locale/en/
     translation_files_expression: 'translations/edx-ora2/openassessment/conf/locale/<lang>/'
 
+
+  # edx-proctoring
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/edx-proctoring/edx_proctoring/conf/locale/en/
+    translation_files_expression: 'translations/edx-proctoring/edx_proctoring/conf/locale/<lang>/'
+
   # frontend-app-account
   - filter_type: file
     file_format: KEYVALUEJSON


### PR DESCRIPTION
feat: Add [edx-proctoring](https://github.com/openedx/edx-proctoring) to the translation pipeline

**IMPORTANT:** This PR needs https://github.com/openedx/edx-proctoring/pull/1124 before it's merged.

- [x] Verified in a test PR in a forked repo: https://github.com/Zeit-Labs/openedx-translations/pull/22/files#r1179222533

Refs:
This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
see details [here](https://github.com/openedx/xblock-submit-and-compare/pull/96)