### PR TITLE
feat: Add edx-ace to the translation pipeline

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -43,6 +43,7 @@ jobs:
           - course-discovery
           - credentials
           - DoneXBlock
+          - edx-ace
           - edx-ora2
           - edx-proctoring
           - RecommenderXBlock

--- a/transifex.yml
+++ b/transifex.yml
@@ -33,6 +33,14 @@ git:
     source_file_dir: translations/DoneXBlock/done/conf/locale/en/
     translation_files_expression: 'translations/DoneXBlock/done/conf/locale/<lang>/'
 
+  # edx-ace
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/edx-ace/edx_ace/conf/locale/en/
+    translation_files_expression: 'translations/edx-ace/edx_ace/conf/locale/<lang>/'
+
   # edx-ora2
   - filter_type: dir
     file_format: PO


### PR DESCRIPTION
feat: Add [edx-ace](https://github.com/openedx/edx-ace) to the translation pipeline

**IMPORTANT:** This PR needs https://github.com/openedx/edx-ace/pull/212 before it's merged.

- [x] Verified in a test PR in a forked repo: https://github.com/Zeit-Labs/openedx-translations/pull/23/files#r1179279363

Refs:
This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
see details [here](https://github.com/openedx/xblock-submit-and-compare/pull/96)