### PR TITLE
feat: Add edx-bulk-grades to the translation pipeline

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -44,6 +44,7 @@ jobs:
           - credentials
           - DoneXBlock
           - edx-ace
+          - edx-bulk-grades
           - edx-ora2
           - edx-proctoring
           - RecommenderXBlock

--- a/transifex.yml
+++ b/transifex.yml
@@ -41,6 +41,14 @@ git:
     source_file_dir: translations/edx-ace/edx_ace/conf/locale/en/
     translation_files_expression: 'translations/edx-ace/edx_ace/conf/locale/<lang>/'
 
+  # edx-bulk-grades
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/edx-bulk-grades/bulk_grades/conf/locale/en/
+    translation_files_expression: 'translations/edx-bulk-grades/bulk_grades/conf/locale/<lang>/'
+
   # edx-ora2
   - filter_type: dir
     file_format: PO


### PR DESCRIPTION
feat: Add [edx-bulk-grades](https://github.com/openedx/edx-bulk-grades) to the translation pipeline

**IMPORTANT:** This PR needs https://github.com/openedx/edx-bulk-grades/pull/151 before it's merged.

- [x] Verified in a test PR in a forked repo: https://github.com/Zeit-Labs/openedx-translations/pull/24/files#r1179324404

Refs:
This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
see details [here](https://github.com/openedx/xblock-submit-and-compare/pull/96)