### PR TITLE
feat: Add xblock-adventure to the translation pipeline

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -61,6 +61,8 @@ jobs:
             python_module_name: feedback
           - repo_name: RecommenderXBlock
             python_module_name: recommender
+          - repo_name: xblock-adventure
+            python_module_name: adventure
           - repo_name: xblock-drag-and-drop-v2
             python_module_name: drag_and_drop_v2
           - repo_name: xblock-free-text-response
@@ -79,7 +81,6 @@ jobs:
             python_module_name: sql_grader
           - repo_name: xblock-submit-and-compare
             python_module_name: submit_and_compare
-
     runs-on: ubuntu-latest
     continue-on-error: true
     needs: [setup-branch]

--- a/transifex.yml
+++ b/transifex.yml
@@ -250,6 +250,14 @@ git:
     source_file: translations/studio-frontend/src/i18n/transifex_input.json
     translation_files_expression: 'translations/studio-frontend/src/i18n/messages/<lang>.json'
 
+  # xblock-adventure
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/xblock-adventure/adventure/conf/locale/en/
+    translation_files_expression: 'translations/xblock-adventure/adventure/conf/locale/<lang>/'
+
   # xblock-drag-and-drop-v2
   - filter_type: dir
     file_format: PO


### PR DESCRIPTION
feat: Add [xblock-adventure](https://github.com/openedx/xblock-adventure) to the translation pipeline

**IMPORTANT:** This PR needs https://github.com/openedx/xblock-adventure/pull/54 before it's merged.

- [x] Verified in a test PR in a forked repo: https://github.com/Zeit-Labs/openedx-translations/pull/26/files#r1181233449

Refs:
This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
see details [here](https://github.com/openedx/xblock-submit-and-compare/pull/96)