### PR TITLE
fix: update makefile to fix typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ piptools:
 	pip install -q -r requirements/pip_tools.txt
 
 upgrade: piptools  ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
-	pip-compile --alow-unsafe --rebuild --upgrade -o requirements/pip.txt requirements/pip.in
+	pip-compile --allow-unsafe --rebuild --upgrade -o requirements/pip.txt requirements/pip.in
 	pip-compile --rebuild --upgrade -o requirements/pip_tools.txt requirements/pip_tools.in
 	pip install -qr requirements/pip.txt
 	pip install -qr requirements/pip_tools.txt


### PR DESCRIPTION
The makefile had `alow-unsafe`. This updates it to have `allow-unsafe`