### PR TITLE
feat: Add xblock-free-text-response to the translation pipeline

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -49,6 +49,7 @@ jobs:
           - edx-proctoring
           - RecommenderXBlock
           - xblock-drag-and-drop-v2
+          - xblock-free-text-response
           - xblock-lti-consumer
           - xblock-qualtrics-survey
           - xblock-submit-and-compare

--- a/transifex.yml
+++ b/transifex.yml
@@ -243,6 +243,14 @@ git:
     source_file_dir: translations/xblock-drag-and-drop-v2/drag_and_drop_v2/conf/locale/en/
     translation_files_expression: 'translations/xblock-drag-and-drop-v2/drag_and_drop_v2/conf/locale/<lang>/'
 
+  # xblock-free-text-response
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/xblock-free-text-response/freetextresponse/conf/locale/en/
+    translation_files_expression: 'translations/xblock-free-text-response/freetextresponse/conf/locale/<lang>/'
+
   # xblock-lti-consumer
   - filter_type: dir
     file_format: PO


### PR DESCRIPTION
feat: Add [xblock-free-text-response](https://github.com/openedx/xblock-free-text-response) to the translation pipeline

**IMPORTANT:** This PR needs https://github.com/openedx/xblock-free-text-response/pull/111 before it's merged.

- [x] Verified in a test PR in a forked repo: https://github.com/Zeit-Labs/openedx-translations/pull/27/files#r1188262917

Refs:
This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
see details [here](https://github.com/openedx/xblock-submit-and-compare/pull/96)