### PR TITLE
feat: Add compile validation step for translation

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -90,6 +90,12 @@ jobs:
           cd translations/${{ matrix.repo }}
           make extract_translations
 
+      # Validate compilation of translation source files
+      - name: validate compilation of translation source files
+        run: |
+          cd translations/${{ matrix.repo }}
+          django-admin compilemessages --locale en
+
       # git adds only the translation source files, found in conf/locale/en
       - name: git add the translation source files
         id: add-sources


### PR DESCRIPTION
feat: Add compile validation step for translation
Compile extracted messages to verify that it will pass in transifex

It happened with one repository and it can happen to others. The process passed here but failed in transifex because of a duplicated msg. To avoid that, we're adding `compilemessages` step after messages extraction to verify that it'll pass in transifex and to catch related errors before merging

Refs: FC-0012 OEP-58