### PR TITLE
feat: Add xblock-google-drive to the translation pipeline

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -51,6 +51,7 @@ jobs:
           - RecommenderXBlock
           - xblock-drag-and-drop-v2
           - xblock-free-text-response
+          - xblock-google-drive
           - xblock-image-explorer
           - xblock-image-modal
           - xblock-lti-consumer

--- a/transifex.yml
+++ b/transifex.yml
@@ -259,6 +259,14 @@ git:
     source_file_dir: translations/xblock-free-text-response/freetextresponse/conf/locale/en/
     translation_files_expression: 'translations/xblock-free-text-response/freetextresponse/conf/locale/<lang>/'
 
+  # xblock-google-drive
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/xblock-google-drive/google_drive/conf/locale/en/
+    translation_files_expression: 'translations/xblock-google-drive/google_drive/conf/locale/<lang>/'
+
   # xblock-image-explorer
   - filter_type: dir
     file_format: PO


### PR DESCRIPTION
feat: Add [xblock-google-drive](https://github.com/openedx/xblock-google-drive) to the translation pipeline

**IMPORTANT:** This PR needs https://github.com/openedx/xblock-google-drive/pull/58 before it's merged.

- [x] Verified in a test PR in a forked repo: https://github.com/Zeit-Labs/openedx-translations/pull/30/files#r1193138674

Refs:
This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
see details [here](https://github.com/openedx/xblock-submit-and-compare/pull/96)