### PR TITLE
feat: Add AudioXBlock to the translation pipeline

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -39,6 +39,7 @@ jobs:
       max-parallel: 1
       matrix:
         repo:
+          - AudioXBlock
           - completion
           - course-discovery
           - credentials

--- a/transifex.yml
+++ b/transifex.yml
@@ -1,6 +1,14 @@
 git:
   filters:
 
+  # AudioXBlock
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/AudioXBlock/audio/conf/locale/en/
+    translation_files_expression: 'translations/AudioXBlock/audio/conf/locale/<lang>/'
+
   # completion
   - filter_type: dir
     file_format: PO


### PR DESCRIPTION
feat: Add [AudioXBlock](https://github.com/openedx/AudioXBlock/pull/89) to the translation pipeline

**IMPORTANT:** This PR needs https://github.com/openedx/AudioXBlock/pull/89 before it's merged.

- [x] Verified in a test PR in a forked repo: https://github.com/Zeit-Labs/openedx-translations/pull/36/files#r1208532233

Refs:
This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
see details [here](https://github.com/openedx/xblock-submit-and-compare/pull/96)