### PR TITLE
feat: Add xblock-sql-grader to the translation pipeline

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -52,6 +52,7 @@ jobs:
           - xblock-free-text-response
           - xblock-lti-consumer
           - xblock-qualtrics-survey
+          - xblock-sql-grader
           - xblock-submit-and-compare
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/transifex.yml
+++ b/transifex.yml
@@ -267,6 +267,14 @@ git:
     source_file_dir: translations/xblock-qualtrics-survey/qualtricssurvey/conf/locale/en/
     translation_files_expression: 'translations/xblock-qualtrics-survey/qualtricssurvey/conf/locale/<lang>/'
 
+  # xblock-sql-grader
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/xblock-sql-grader/sql_grader/conf/locale/en/
+    translation_files_expression: 'translations/xblock-sql-grader/sql_grader/conf/locale/<lang>/'
+
   # xblock-submit-and-compare
   - filter_type: dir
     file_format: PO


### PR DESCRIPTION
feat: Add [xblock-sql-grader](https://github.com/openedx/xblock-sql-grader) to the translation pipeline

**IMPORTANT:** This PR needs https://github.com/openedx/xblock-sql-grader/pull/100 before it's merged.

- [x] Verified in a test PR in a forked repo: https://github.com/Zeit-Labs/openedx-translations/pull/37/files#r1208547294

Refs:
This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
see details [here](https://github.com/openedx/xblock-submit-and-compare/pull/96)