### PR TITLE
fix: provide secret transifex api token via env

### DIFF
--- a/.github/workflows/fix-transifex-resource-names.yml
+++ b/.github/workflows/fix-transifex-resource-names.yml
@@ -27,6 +27,8 @@ jobs:
 
       # Run the script
       - name: Fix transifex automatic resource names
+        env:
+          TRANSIFEX_API_TOKEN: ${{ secrets.TRANSIFEX_API_TOKEN }} 
         run: |
           make transifex_resources_requirements
           make fix_transifex_resource_names


### PR DESCRIPTION
`fix_transifex_resource_names.py` requires a Transifex API token. We have this token stored in the repo as a secret. This PR updates the actions workflow to provide the token to the script as an environment variable.