### PR TITLE
feat: Add credentials-themes to the translation pipeline

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -43,6 +43,7 @@ jobs:
           - completion
           - course-discovery
           - credentials
+          - credentials-themes
           - DoneXBlock
           - edx-ace
           - edx-bulk-grades

--- a/transifex.yml
+++ b/transifex.yml
@@ -33,6 +33,14 @@ git:
     source_file_dir: translations/credentials/credentials/conf/locale/en/
     translation_files_expression: 'translations/credentials/credentials/conf/locale/<lang>/'
 
+  # credentials-themes
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/credentials-themes/edx_credentials_themes/conf/locale/en/
+    translation_files_expression: 'translations/credentials-themes/edx_credentials_themes/conf/locale/<lang>/'
+
   # DoneXBlock
   - filter_type: dir
     file_format: PO
@@ -80,7 +88,7 @@ git:
     source_language: en
     source_file_dir: translations/FeedbackXBlock/feedback/conf/locale/en/
     translation_files_expression: 'translations/FeedbackXBlock/feedback/conf/locale/<lang>/'
-  
+
   # frontend-app-account
   - filter_type: file
     file_format: KEYVALUEJSON


### PR DESCRIPTION
feat: Add [credentials-themes](https://github.com/openedx/credentials-themes) to the translation pipeline

**IMPORTANT:** This PR needs https://github.com/openedx/credentials-themes/pull/613 before it's merged.

- [x] Verified in a test PR in a forked repo: https://github.com/Zeit-Labs/openedx-translations/pull/75/files#r1332758489

Refs:
This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
see details [here](https://github.com/openedx/xblock-submit-and-compare/pull/96)