### PR TITLE
feat: upgrade requirements to have the edx-i18n-tools 1.0.0

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.1.2
+pip==23.2
     # via -r requirements/pip.in
-setuptools==67.8.0
+setuptools==68.0.0
     # via -r requirements/pip.in

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -6,16 +6,18 @@
 #
 build==0.10.0
     # via pip-tools
-click==8.1.3
+click==8.1.6
     # via pip-tools
 packaging==23.1
     # via build
-pip-tools==6.13.0
+pip-tools==7.1.0
     # via -r requirements/pip_tools.in
 pyproject-hooks==1.0.0
     # via build
 tomli==2.0.1
-    # via build
+    # via
+    #   build
+    #   pip-tools
 wheel==0.40.0
     # via pip-tools
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,15 +12,15 @@ certifi==2023.5.7
     # via
     #   -r requirements/transifex-resources.txt
     #   requests
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via
     #   -r requirements/transifex-resources.txt
     #   requests
-click==8.1.3
+click==8.1.6
     # via
     #   -r requirements/transifex-resources.txt
     #   transifex-python
-exceptiongroup==1.1.1
+exceptiongroup==1.1.2
     # via pytest
 future==0.18.3
     # via
@@ -38,19 +38,19 @@ parsimonious==0.10.0
     # via
     #   -r requirements/transifex-resources.txt
     #   pyseeyou
-pluggy==1.0.0
+pluggy==1.2.0
     # via pytest
 pyseeyou==1.0.2
     # via
     #   -r requirements/transifex-resources.txt
     #   transifex-python
-pytest==7.3.1
+pytest==7.4.0
     # via -r requirements/test.in
 pytz==2023.3
     # via
     #   -r requirements/transifex-resources.txt
     #   transifex-python
-regex==2023.5.5
+regex==2023.6.3
     # via
     #   -r requirements/transifex-resources.txt
     #   parsimonious
@@ -68,9 +68,9 @@ toolz==0.12.0
     # via
     #   -r requirements/transifex-resources.txt
     #   pyseeyou
-transifex-python==3.3.0
+transifex-python==3.4.0
     # via -r requirements/transifex-resources.txt
-urllib3==2.0.2
+urllib3==2.0.4
     # via
     #   -r requirements/transifex-resources.txt
     #   requests

--- a/requirements/transifex-resources.txt
+++ b/requirements/transifex-resources.txt
@@ -8,9 +8,9 @@ asttokens==2.2.1
     # via transifex-python
 certifi==2023.5.7
     # via requests
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via requests
-click==8.1.3
+click==8.1.6
     # via transifex-python
 future==0.18.3
     # via pyseeyou
@@ -22,7 +22,7 @@ pyseeyou==1.0.2
     # via transifex-python
 pytz==2023.3
     # via transifex-python
-regex==2023.5.5
+regex==2023.6.3
     # via parsimonious
 requests==2.31.0
     # via transifex-python
@@ -30,7 +30,7 @@ six==1.16.0
     # via asttokens
 toolz==0.12.0
     # via pyseeyou
-transifex-python==3.3.0
+transifex-python==3.4.0
     # via -r requirements/transifex-resources.in
-urllib3==2.0.2
+urllib3==2.0.4
     # via requests

--- a/requirements/translations.txt
+++ b/requirements/translations.txt
@@ -4,21 +4,23 @@
 #
 #    make upgrade
 #
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
-django==3.2.19
+django==3.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   edx-i18n-tools
-edx-i18n-tools==0.9.2
+edx-i18n-tools==1.0.0
     # via -r requirements/translations.in
-path==16.6.0
+path==16.7.1
     # via edx-i18n-tools
 polib==1.2.0
     # via edx-i18n-tools
 pytz==2023.3
     # via django
-pyyaml==6.0
+pyyaml==6.0.1
     # via edx-i18n-tools
 sqlparse==0.4.4
     # via django
+typing-extensions==4.7.1
+    # via asgiref


### PR DESCRIPTION
Upgrading requirements using `make upgrade`

The main reason is to have `edx-i18n-tools==1.0.0` so we can include [this fix](https://github.com/openedx/i18n-tools/pull/129) in the process