### PR TITLE
fix: Fix wrong key (repo) to be (repo_name)

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -65,11 +65,11 @@ jobs:
             python_module_name: drag_and_drop_v2
           - repo_name: xblock-free-text-response
             python_module_name: freetextresponse
-          - repo: xblock-google-drive
+          - repo_name: xblock-google-drive
             python_module_name: google_drive
-          - repo: xblock-image-explorer
+          - repo_name: xblock-image-explorer
             python_module_name: image_explorer
-          - repo: xblock-image-modal
+          - repo_name: xblock-image-modal
             python_module_name: imagemodal
           - repo_name: xblock-lti-consumer
             python_module_name: lti_consumer


### PR DESCRIPTION
My bad! the key I used for these repositories was `repo` which is wrong. The correct one is `repo_name`