### PR TITLE
docs: fix typo `module_name` -> `python_module_name`

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -39,8 +39,8 @@ jobs:
       max-parallel: 1
       matrix:
         repo:
-          # Note: Add `module_name` for all edx-platform plugins and XBlocks such as DoneXBlock and completion, but not
-          #       for micrsoervices and IDAs such as course-discovery and credentials.
+          # Note: Add `python_module_name` for all edx-platform plugins and XBlocks such as DoneXBlock and completion,
+          #       but not for micrsoervices and IDAs such as course-discovery and credentials.
           - repo_name: AudioXBlock
             python_module_name: audio
           - repo_name: completion


### PR DESCRIPTION
The fix amends an outdated matrix yaml config.

This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).