### PR TITLE
fix: validate translation files only when it's changed

### DIFF
--- a/.github/workflows/validate-translation-files.yml
+++ b/.github/workflows/validate-translation-files.yml
@@ -3,7 +3,9 @@
 name: Validate translation PO files
 
 on:
-  - pull_request
+  pull_request:
+    paths:
+      - 'translations/**'
 
 jobs:
   validate-po-files:


### PR DESCRIPTION
This helps to avoid breaking PR builds due to translation issues even though it's not the PR's fault.

------

This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
