### PR TITLE
feat: Special support for XBlocks

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -149,6 +149,22 @@ jobs:
           # extract_translations into EN_DIR and adds them
           DJANGO_PATH=$(find $EN_DIR -name 'django.po')
           DJANGOJS_PATH=$(find $EN_DIR -name 'djangojs.po')
+          ############## Special support for XBlocks
+          # if both files are not found, then it can be an XBlock (thus, text.po and textjs.po files)
+          if [ -z "$DJANGO_PATH" ] && [ -z "$DJANGOJS_PATH" ]; then
+            DJANGO_PATH=$(find $EN_DIR -name 'text.po')
+            DJANGOJS_PATH=$(find $EN_DIR -name 'textjs.po')
+            # Rename the files to django.po and djangojs.po, if exists
+            if [ -n "$DJANGO_PATH" ]; then
+              mv $DJANGO_PATH $(dirname $DJANGO_PATH)/django.po
+              DJANGO_PATH=$(dirname $DJANGO_PATH)/django.po
+            fi
+            if [ -n "$DJANGOJS_PATH" ]; then
+              mv $DJANGOJS_PATH $(dirname $DJANGOJS_PATH)/djangojs.po
+              DJANGOJS_PATH=$(dirname $DJANGOJS_PATH)/djangojs.po
+            fi
+          fi
+          ############## End of - Special support for XBlocks
           # use (-f) to force add the files even if they are ignored in the source repo
           git add $DJANGO_PATH $DJANGOJS_PATH -f -v
           # Check the git statuses of the translation source files


### PR DESCRIPTION
feat: Special support for XBlocks

XBlocks require `text.po` and `textjs.po` instead of `django.po` and `djangojs.po`. This PR will add support to find XBlock translation files and rename them to `django` during translation extraction.

**Why is this needed?**

After moving along with standardizing `make extract_translations` in XBlocks; we found that it's safer to keep `text.po` and `textjs.po` as the translation domains for XBlocks. It's to preserve compatibility with in-repo translations since it'll be used for a while by the community

See this related conversation https://github.com/openedx/edx-cookiecutters/pull/382#discussion_r1300041928

- [x] Tested in a forked PR https://github.com/Zeit-Labs/openedx-translations/pull/67/files. The tested XBlock is a fork containing `text.po` as the domain for translation https://github.com/Zeit-Labs/xblock-drag-and-drop-v2/blob/9956abde00175e3d53dff53502b10fafbd6af0d3/Makefile#L12 
