### PR TITLE
feat: fix random and lengthy slugs and support `-js` suffix

### DIFF
--- a/.github/workflows/fix-transifex-resource-names.yml
+++ b/.github/workflows/fix-transifex-resource-names.yml
@@ -9,6 +9,8 @@ on:
     paths:
       - 'transifex.yml'
       - '.github/workflows/extract-translation-source-files.yml'
+  schedule:  # Also run monthly just in case there's a stall slug/name update
+    - cron: '0 0 1 * *'
 
 jobs:
   python-translations:
@@ -28,7 +30,7 @@ jobs:
       # Run the script
       - name: Fix transifex automatic resource names
         env:
-          TRANSIFEX_API_TOKEN: ${{ secrets.TRANSIFEX_API_TOKEN }} 
+          TRANSIFEX_API_TOKEN: ${{ secrets.TRANSIFEX_API_TOKEN }}
         run: |
           make transifex_resources_requirements
           make fix_transifex_resource_names

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 __pycache__
 .pytest_cache
+*,cover
+.coverage
+htmlcov
 
 # msgfmt sometimes leaves these behind in the root directory
 /*.mo

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test_requirements:  ## Installs test.txt requirements
 	pip install -q -r requirements/test.txt
 
 test:  ## Run scripts tests
-	 pytest -v -s scripts/tests
+	 pytest -v -s --cov=. --cov-report=term-missing --cov-report=html scripts/tests
 
 validate_translation_files:  ## Run basic validation to ensure files are compilable
 	find translations/ -name '*.po' \

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.41.1
+wheel==0.41.2
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.2.1
     # via -r requirements/pip.in
-setuptools==68.1.2
+setuptools==68.2.0
     # via -r requirements/pip.in

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,10 +4,12 @@
 #
 #    make upgrade
 #
-build==0.10.0
+build==1.0.3
     # via pip-tools
 click==8.1.7
     # via pip-tools
+importlib-metadata==6.8.0
+    # via build
 packaging==23.1
     # via build
 pip-tools==7.3.0
@@ -19,8 +21,10 @@ tomli==2.0.1
     #   build
     #   pip-tools
     #   pyproject-hooks
-wheel==0.41.1
+wheel==0.41.2
     # via pip-tools
+zipp==3.16.2
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -2,4 +2,5 @@
 -r transifex.txt
 
 pytest
+pytest-cov
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-asttokens==2.2.1
+asttokens==2.4.0
     # via
     #   -r requirements/transifex.txt
     #   transifex-python
@@ -20,6 +20,8 @@ click==8.1.7
     # via
     #   -r requirements/transifex.txt
     #   transifex-python
+coverage[toml]==7.3.1
+    # via pytest-cov
 exceptiongroup==1.1.3
     # via pytest
 future==0.18.3
@@ -30,7 +32,7 @@ gitdb==4.0.10
     # via
     #   -r requirements/transifex.txt
     #   gitpython
-gitpython==3.1.32
+gitpython==3.1.35
     # via
     #   -r requirements/transifex.txt
     #   transifex-client
@@ -46,19 +48,23 @@ parsimonious==0.10.0
     # via
     #   -r requirements/transifex.txt
     #   pyseeyou
-pluggy==1.2.0
+pluggy==1.3.0
     # via pytest
 pyseeyou==1.0.2
     # via
     #   -r requirements/transifex.txt
     #   transifex-python
-pytest==7.4.0
+pytest==7.4.2
+    # via
+    #   -r requirements/test.in
+    #   pytest-cov
+pytest-cov==4.1.0
     # via -r requirements/test.in
 python-slugify==4.0.1
     # via
     #   -r requirements/transifex.txt
     #   transifex-client
-pytz==2023.3
+pytz==2023.3.post1
     # via
     #   -r requirements/transifex.txt
     #   transifex-python
@@ -85,7 +91,9 @@ text-unidecode==1.3
     #   -r requirements/transifex.txt
     #   python-slugify
 tomli==2.0.1
-    # via pytest
+    # via
+    #   coverage
+    #   pytest
 toolz==0.12.0
     # via
     #   -r requirements/transifex.txt

--- a/requirements/transifex.txt
+++ b/requirements/transifex.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-asttokens==2.2.1
+asttokens==2.4.0
     # via transifex-python
 certifi==2023.7.22
     # via requests
@@ -16,7 +16,7 @@ future==0.18.3
     # via pyseeyou
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.32
+gitpython==3.1.35
     # via transifex-client
 idna==3.4
     # via requests
@@ -26,7 +26,7 @@ pyseeyou==1.0.2
     # via transifex-python
 python-slugify==4.0.1
     # via transifex-client
-pytz==2023.3
+pytz==2023.3.post1
     # via transifex-python
 regex==2023.8.8
     # via parsimonious

--- a/requirements/translations.txt
+++ b/requirements/translations.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.7.2
     # via django
-django==3.2.20
+django==3.2.21
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   edx-i18n-tools
@@ -16,7 +16,7 @@ path==16.7.1
     # via edx-i18n-tools
 polib==1.2.0
     # via edx-i18n-tools
-pytz==2023.3
+pytz==2023.3.post1
     # via django
 pyyaml==6.0.1
     # via edx-i18n-tools

--- a/scripts/fix_transifex_resource_names.py
+++ b/scripts/fix_transifex_resource_names.py
@@ -1,10 +1,10 @@
 """
-Set the openedx-translations to readable resource names:
+Set the openedx-translations to readable resource names and slugs:
 
 Run via `$ make fix_transifex_resource_names`.
 
 
-Transifex sets resource slug names to a long name which makes it unreadable by translators .e.g.
+Transifex sets resource slug names and slugs to a long name which makes it unreadable by translators .e.g.
  - "translations..frontend-app-something..src-i18n-transifex-input--main"
 
 This script infer the resource name in two ways:
@@ -14,7 +14,12 @@ This script infer the resource name in two ways:
 
 2) If no usable slug is available, infer the resource name from the categories e.g.
  - ["github#repository:openedx/openedx-translations#branch:main#path:translations/my-xblock/openassessment/conf/locale/en/LC_MESSAGES/djangojs.po"]
-   would result in "my-xblock" as resource name.
+   would result in "my-xblock-js" as resource name.
+
+Slugs are even worse, sometimes they're also the lengthy while other times they're just hashes e.g.
+ - "b8933764bdb3063ca09d6aa20341102f"
+
+This script updates slugs to be like names.
 """
 
 import configparser
@@ -23,7 +28,15 @@ import sys
 from os import getenv
 from os.path import expanduser
 
+from slugify import slugify
 from transifex.api import transifex_api
+
+
+def is_dry_run():
+    """
+    Check if the script is running in debug mode.
+    """
+    return '--dry-run' in sys.argv
 
 
 def get_transifex_project():
@@ -48,14 +61,7 @@ def get_transifex_project():
     return openedx_org.fetch('projects').get(slug='openedx-translations')
 
 
-def get_repo_name_from_resource(resource):
-    if resource.slug.startswith('translations-'):
-        # example resource.slug = (
-        #     "translations-my-xblock-conf-locale-en-lc-messages-django-po--main"
-        # )
-        new_name = re.sub(r'(^translations-|-src-i18n-.*--main$|-conf-locale-.*--main)', '', resource.slug)
-        return new_name
-
+def get_repo_slug_from_resource(resource):
     if resource.categories:
         github_repo_categories = [
             category for category in resource.categories if 'github#repository' in category
@@ -70,7 +76,23 @@ def get_repo_name_from_resource(resource):
             if '#path:translations/' in github_repo_info:
                 path_name = github_repo_info.split('#path:translations/')[1]
                 directory_name = path_name.split('/')[0]
-                return directory_name
+                if github_repo_info.endswith('js.po'):
+                    return slugify(f'{directory_name}-js')
+                else:
+                    return slugify(directory_name)
+
+    if resource.slug.startswith('translations-'):
+        # example resource.slug:
+        # - "translations-my-xblock-conf-locale-en-lc-messages-django-po--main"
+        # - "translations-frontend-app-library-authoring-src-i18n-transifex-input-json--main"
+        #
+        results = re.search(r'translations-(.*)-(conf-locale|src-i18n)', resource.slug)
+        if results:
+            if new_name := results.group(1):
+                if 'djangojs-po' in resource.slug:
+                    return f'{new_name}-js'
+                else:
+                    return new_name
 
 
 def main(argv):
@@ -79,31 +101,48 @@ def main(argv):
         print(__doc__)
         return
 
-    print('Updating openedx-translations project resource names:')
+    print('Updating openedx-translations project resource and slug names:')
 
     openedx_translations_proj = get_transifex_project()
     for resource in openedx_translations_proj.fetch('resources'):
-        if resource.name.startswith('translations..'):
-            print('------------')
-            print('Updating:')
-            print('Resource id:', resource.id)
-            print('Resource slug:', resource.slug)
-            print('Resource name:', resource.name)
-            print('Resource categories:', ', '.join(resource.categories))
+        print('------------')
+        print('Updating:')
+        print('Resource id:', resource.id)
+        print('Resource slug:', resource.slug)
+        print('Resource name:', resource.name)
+        print('Resource categories:', ', '.join(resource.categories))
 
-            new_name = get_repo_name_from_resource(resource)
-            if new_name:
-                if '--dry-run' in argv:
-                    print('Saving new name (dry run):', new_name, '\n')
+        new_name = get_repo_slug_from_resource(resource)
+        new_slug = get_repo_slug_from_resource(resource)
+
+        if resource.name.startswith('translations..'):
+            if new_name and resource.name != new_name:
+                resource.name = new_name
+                if is_dry_run():
+                    print(f'\n### Saving new name "{new_name}" (dry-run) ###', '\n')
                 else:
-                    print('Saving new name:', new_name, '\n')
-                    resource.name = new_name
+                    print(f'\n### Saving new name "{new_name}" ###', '\n')
                     resource.save('name')
             else:
-                print(f'Error: Unrecognized slug pattern "{resource.slug}" or categories "{resource.categories}" '
-                      f'to infer resource name from.')
+                print(f'Error: Unrecognized slug pattern or categories to infer resource resource name from.')
+
+        if re.match('^[a-z0-9]{32}$', resource.slug) or resource.slug.startswith('translations-'):
+            if new_slug and resource.slug != new_slug:
+                resource.slug = new_slug
+                if is_dry_run():
+                    print(f'\n### Saving new slug "{new_slug}" (dry-run) ###', '\n')
+                else:
+                    print(f'\n### Saving new slug "{new_slug}" ###', '\n')
+                    try:
+                        resource.save('slug')
+                    except Exception as e:
+                        # Slug is unique, so if it already exists, we get an error.
+                        print(f'Error: {e}')
+            else:
+                print(f'Error: Unrecognized slug pattern or categories to infer resource slug from.')
+
         else:
-            print(f'Skipping: "{resource.name}" because it seems to have a proper name (id={resource.id})')
+            print(f'Skipping: "{resource.name}" because it seems to have proper attributes')
 
 
 if __name__ == '__main__':

--- a/scripts/tests/test_fix_transifex_resource_names.py
+++ b/scripts/tests/test_fix_transifex_resource_names.py
@@ -3,35 +3,49 @@ Tests for fix_transifex_resource_names.py.
 """
 import unittest
 from unittest.mock import MagicMock
-from ..fix_transifex_resource_names import get_repo_name_from_resource
+from ..fix_transifex_resource_names import get_repo_slug_from_resource
 
 
-def test_get_repo_name_from_resource_with_no_categories():
+def test_get_repo_slug_from_resource_with_no_categories():
     resource = MagicMock()
     resource.slug = 'translations-my-xblock-conf-locale-en-lc-messages-django-po--main'
     resource.categories = []
-    assert get_repo_name_from_resource(resource) == 'my-xblock'
+    assert get_repo_slug_from_resource(resource) == 'my-xblock'
+
+
+def test_get_repo_slug_from_resource_slug_js_with_no_categories():
+    resource = MagicMock()
+    resource.slug = 'translations-my-xblock-conf-locale-en-lc-messages-djangojs-po--main'
+    resource.categories = []
+    assert get_repo_slug_from_resource(resource) == 'my-xblock-js'
 
 
 def test_get_repo_name_from_invalid_slug():
     resource = MagicMock()
     resource.slug = 'some-gibberish-slug'
     resource.categories = []
-    assert get_repo_name_from_resource(resource) == None
+    assert get_repo_slug_from_resource(resource) == None
 
 
 def test_get_repo_name_from_slug_and_categories():
     """
-    Slug takes precedence over categories.
+    Categories takes precedence over slug.
     """
     resource = MagicMock()
     resource.slug = 'translations-my-xblock1-conf-locale-en-lc-messages-django-po--main'
-    resource.categories = ['github#repository:openedx/openedx-translations#branch:main#path:translations/my-xblock2/openassessment/conf/locale/en/LC_MESSAGES/djangojs.po']  # noqa
-    assert get_repo_name_from_resource(resource) == 'my-xblock1'
+    resource.categories = ['github#repository:openedx/openedx-translations#branch:main#path:translations/my-xblock2/openassessment/conf/locale/en/LC_MESSAGES/django.po']  # noqa
+    assert get_repo_slug_from_resource(resource) == 'my-xblock2'
 
 
 def test_get_repo_name_from_categories():
     resource = MagicMock()
     resource.slug = 'some-gibberish-slug'
+    resource.categories = ['github#repository:openedx/openedx-translations#branch:main#path:translations/my-xblock2/openassessment/conf/locale/en/LC_MESSAGES/django.po']  # noqa
+    assert get_repo_slug_from_resource(resource) == 'my-xblock2'
+
+
+def test_get_repo_name_from_categories_with_js():
+    resource = MagicMock()
+    resource.slug = 'some-gibberish-slug'
     resource.categories = ['github#repository:openedx/openedx-translations#branch:main#path:translations/my-xblock2/openassessment/conf/locale/en/LC_MESSAGES/djangojs.po']  # noqa
-    assert get_repo_name_from_resource(resource) == 'my-xblock2'
+    assert get_repo_slug_from_resource(resource) == 'my-xblock2-js'


### PR DESCRIPTION
### Changes
- chore: add pytest-cov
- feat: fix resource names monthly: To give some time leeway for Transifex to add new resources as opposed to expect it to add the resource immediately after a pull request is merged.
- feat: fix random and lengthy slugs and support `-js` suffix

### Testing

 - [x] Added basic unit tests for the new cases
 - [x] Tested in dry-run
 - [x] Ran locally and updated all Transifex resources
 - [x] Fix errors manually for duplicate slugs by hand

<details><summary>Test results</summary>

```
$ make fix_transifex_resource_names
python scripts/fix_transifex_resource_names.py
Updating openedx-translations project resource and slug names:
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:audioxblock
Resource slug: audioxblock
Resource name: AudioXBlock
Resource categories: github#repository:openedx/openedx-translations#branch:main#path:translations/AudioXBlock/audio/conf/locale/en/LC_MESSAGES/django.po
Skipping: "AudioXBlock" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:completion
Resource slug: completion
Resource name: completion
Resource categories: github#repository:openedx/openedx-translations#branch:main#path:translations/completion/completion/conf/locale/en/LC_MESSAGES/django.po
Skipping: "completion" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:course-discovery
Resource slug: course-discovery
Resource name: course-discovery
Resource categories: 
Skipping: "course-discovery" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:course-discovery-js
Resource slug: course-discovery-js
Resource name: course-discovery-js
Resource categories: 
Skipping: "course-discovery-js" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:credentials
Resource slug: credentials
Resource name: credentials
Resource categories: 
Skipping: "credentials" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:credentials-js
Resource slug: credentials-js
Resource name: credentials-js
Resource categories: 
Skipping: "credentials-js" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:donexblock
Resource slug: donexblock
Resource name: DoneXBlock
Resource categories: github#repository:openedx/openedx-translations#branch:main#path:translations/DoneXBlock/done/conf/locale/en/LC_MESSAGES/django.po
Skipping: "DoneXBlock" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:edx-ace
Resource slug: edx-ace
Resource name: edx-ace
Resource categories: github#repository:openedx/openedx-translations#branch:main#path:translations/edx-ace/edx_ace/conf/locale/en/LC_MESSAGES/django.po
Skipping: "edx-ace" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:edx-bulk-grades
Resource slug: edx-bulk-grades
Resource name: edx-bulk-grades
Resource categories: github#repository:openedx/openedx-translations#branch:main#path:translations/edx-bulk-grades/bulk_grades/conf/locale/en/LC_MESSAGES/django.po
Skipping: "edx-bulk-grades" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:edx-ora2
Resource slug: edx-ora2
Resource name: edx-ora2
Resource categories: github#repository:openedx/openedx-translations#branch:main#path:translations/edx-ora2/openassessment/conf/locale/en/LC_MESSAGES/django.po
Skipping: "edx-ora2" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:edx-ora2-js
Resource slug: edx-ora2-js
Resource name: edx-ora2-js
Resource categories: github#repository:openedx/openedx-translations#branch:main#path:translations/edx-ora2/openassessment/conf/locale/en/LC_MESSAGES/djangojs.po
Skipping: "edx-ora2-js" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:edx-proctoring
Resource slug: edx-proctoring
Resource name: edx-proctoring
Resource categories: github#repository:openedx/openedx-translations#branch:main#path:translations/edx-proctoring/edx_proctoring/conf/locale/en/LC_MESSAGES/django.po
Skipping: "edx-proctoring" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:edx-proctoring-js
Resource slug: edx-proctoring-js
Resource name: edx-proctoring-js
Resource categories: github#repository:openedx/openedx-translations#branch:main#path:translations/edx-proctoring/edx_proctoring/conf/locale/en/LC_MESSAGES/djangojs.po
Skipping: "edx-proctoring-js" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:feedbackxblock
Resource slug: feedbackxblock
Resource name: FeedbackXBlock
Resource categories: github#repository:openedx/openedx-translations#branch:main#path:translations/FeedbackXBlock/feedback/conf/locale/en/LC_MESSAGES/django.po
Skipping: "FeedbackXBlock" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:frontend-app-account
Resource slug: frontend-app-account
Resource name: frontend-app-account
Resource categories: 
Skipping: "frontend-app-account" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:frontend-app-authn
Resource slug: frontend-app-authn
Resource name: frontend-app-authn
Resource categories: 
Skipping: "frontend-app-authn" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:frontend-app-communications
Resource slug: frontend-app-communications
Resource name: frontend-app-communications
Resource categories: 
Skipping: "frontend-app-communications" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:frontend-app-course-authoring
Resource slug: frontend-app-course-authoring
Resource name: frontend-app-course-authoring
Resource categories: 
Skipping: "frontend-app-course-authoring" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:frontend-app-discussions
Resource slug: frontend-app-discussions
Resource name: frontend-app-discussions
Resource categories: 
Skipping: "frontend-app-discussions" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:frontend-app-ecommerce
Resource slug: frontend-app-ecommerce
Resource name: frontend-app-ecommerce
Resource categories: 
Skipping: "frontend-app-ecommerce" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:frontend-app-enterprise-public-catalog
Resource slug: frontend-app-enterprise-public-catalog
Resource name: frontend-app-enterprise-public-catalog
Resource categories: 
Skipping: "frontend-app-enterprise-public-catalog" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:frontend-app-gradebook
Resource slug: frontend-app-gradebook
Resource name: frontend-app-gradebook
Resource categories: 
Skipping: "frontend-app-gradebook" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:frontend-app-learner-dashboard
Resource slug: frontend-app-learner-dashboard
Resource name: frontend-app-learner-dashboard
Resource categories: 
Skipping: "frontend-app-learner-dashboard" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:frontend-app-learner-record
Resource slug: frontend-app-learner-record
Resource name: frontend-app-learner-record
Resource categories: 
Skipping: "frontend-app-learner-record" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:frontend-app-learning
Resource slug: frontend-app-learning
Resource name: frontend-app-learning
Resource categories: 
Skipping: "frontend-app-learning" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:frontend-app-library-authoring
Resource slug: frontend-app-library-authoring
Resource name: frontend-app-library-authoring
Resource categories: 
Skipping: "frontend-app-library-authoring" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:frontend-app-ora-grading
Resource slug: frontend-app-ora-grading
Resource name: frontend-app-ora-grading
Resource categories: 
Skipping: "frontend-app-ora-grading" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:frontend-app-payment
Resource slug: frontend-app-payment
Resource name: frontend-app-payment
Resource categories: 
Skipping: "frontend-app-payment" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:frontend-app-profile
Resource slug: frontend-app-profile
Resource name: frontend-app-profile
Resource categories: 
Skipping: "frontend-app-profile" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:frontend-app-program-console
Resource slug: frontend-app-program-console
Resource name: frontend-app-program-console
Resource categories: 
Skipping: "frontend-app-program-console" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:frontend-app-support-tools
Resource slug: frontend-app-support-tools
Resource name: frontend-app-support-tools
Resource categories: 
Skipping: "frontend-app-support-tools" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:frontend-component-footer
Resource slug: frontend-component-footer
Resource name: frontend-component-footer
Resource categories: 
Skipping: "frontend-component-footer" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:frontend-component-header
Resource slug: frontend-component-header
Resource name: frontend-component-header
Resource categories: 
Skipping: "frontend-component-header" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:frontend-lib-content-components
Resource slug: frontend-lib-content-components
Resource name: frontend-lib-content-components
Resource categories: github#repository:openedx/openedx-translations#branch:main#path:translations/frontend-lib-content-components/src/i18n/transifex_input.json
Skipping: "frontend-lib-content-components" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:frontend-lib-special-exams
Resource slug: frontend-lib-special-exams
Resource name: frontend-lib-special-exams
Resource categories: github#repository:openedx/openedx-translations#branch:main#path:translations/frontend-lib-special-exams/src/i18n/transifex_input.json
Skipping: "frontend-lib-special-exams" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:paragon
Resource slug: paragon
Resource name: paragon
Resource categories: 
Skipping: "paragon" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:recommenderxblock
Resource slug: recommenderxblock
Resource name: RecommenderXBlock
Resource categories: github#repository:openedx/openedx-translations#branch:main#path:translations/RecommenderXBlock/recommender/conf/locale/en/LC_MESSAGES/django.po
Skipping: "RecommenderXBlock" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:studio-frontend
Resource slug: studio-frontend
Resource name: studio-frontend
Resource categories: github#repository:openedx/openedx-translations#branch:main#path:translations/studio-frontend/src/i18n/transifex_input.json
Skipping: "studio-frontend" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:xblock-drag-and-drop-v2
Resource slug: xblock-drag-and-drop-v2
Resource name: xblock-drag-and-drop-v2
Resource categories: github#repository:openedx/openedx-translations#branch:main#path:translations/xblock-drag-and-drop-v2/drag_and_drop_v2/conf/locale/en/LC_MESSAGES/django.po
Skipping: "xblock-drag-and-drop-v2" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:xblock-free-text-response
Resource slug: xblock-free-text-response
Resource name: xblock-free-text-response
Resource categories: github#repository:openedx/openedx-translations#branch:main#path:translations/xblock-free-text-response/freetextresponse/conf/locale/en/LC_MESSAGES/django.po
Skipping: "xblock-free-text-response" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:xblock-google-drive
Resource slug: xblock-google-drive
Resource name: xblock-google-drive
Resource categories: github#repository:openedx/openedx-translations#branch:main#path:translations/xblock-google-drive/google_drive/conf/locale/en/LC_MESSAGES/django.po
Skipping: "xblock-google-drive" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:xblock-image-explorer
Resource slug: xblock-image-explorer
Resource name: xblock-image-explorer
Resource categories: github#repository:openedx/openedx-translations#branch:main#path:translations/xblock-image-explorer/image_explorer/conf/locale/en/LC_MESSAGES/django.po
Skipping: "xblock-image-explorer" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:xblock-image-modal
Resource slug: xblock-image-modal
Resource name: xblock-image-modal
Resource categories: github#repository:openedx/openedx-translations#branch:main#path:translations/xblock-image-modal/imagemodal/conf/locale/en/LC_MESSAGES/django.po
Skipping: "xblock-image-modal" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:xblock-lti-consumer
Resource slug: xblock-lti-consumer
Resource name: xblock-lti-consumer
Resource categories: github#repository:openedx/openedx-translations#branch:main#path:translations/xblock-lti-consumer/lti_consumer/conf/locale/en/LC_MESSAGES/django.po
Skipping: "xblock-lti-consumer" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:xblock-qualtrics-survey
Resource slug: xblock-qualtrics-survey
Resource name: xblock-qualtrics-survey
Resource categories: github#repository:openedx/openedx-translations#branch:main#path:translations/xblock-qualtrics-survey/qualtricssurvey/conf/locale/en/LC_MESSAGES/django.po
Skipping: "xblock-qualtrics-survey" because it seems to have a proper attributes
------------
Updating:
Resource id: o:open-edx:p:openedx-translations:r:xblock-sql-grader
Resource slug: xblock-sql-grader
Resource name: xblock-sql-grader
Resource categories: github#repository:openedx/openedx-translations#branch:main#path:translations/xblock-sql-grader/sql_grader/conf/locale/en/LC_MESSAGES/django.po
Skipping: "xblock-sql-grader" because it seems to have a proper attributes

```

</details> 

This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
