### PR TITLE
fix: fatal translations error to make CI run again

### DIFF
--- a/translations/edx-ora2/openassessment/conf/locale/ar/LC_MESSAGES/django.po
+++ b/translations/edx-ora2/openassessment/conf/locale/ar/LC_MESSAGES/django.po
@@ -3,10 +3,10 @@
 # Copyright (C) 2018 edX
 # This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
 # EdX Team <info@edx.org>, 2018.
-# 
+#
 # Translators:
 # Omar Al-Ithawi <i@omardo.com>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: edx-ora2\n"
@@ -1625,9 +1625,7 @@ msgid ""
 "                                      You will not be part of Team %(team_name)s’s submission for this assignment and will not\n"
 "                                      receive a grade for their submission.\n"
 "                                  "
-msgstr ""
-"\n"
-"أنت الآن عضو في فريق %(team_name)s. نظرًا لأنك كنت في فريق %(previous_team_name)s عندما أرسلوا ردًا على هذه المهمة ، فإنك تشاهد استجابة فريق %(previous_team_name)s وستتلقى نفس الدرجة لهذه المهمة مثل زملائك السابقين في الفريق. لن تكون جزءًا من إرسال فريق %(team_name)s لهذا الواجب ولن تتلقى تقديرًا لإرساله."
+msgstr "\n                                      أنت الآن عضو في فريق %(team_name)s. نظرًا لأنك كنت في فريق %(previous_team_name)s عندما أرسلوا ردًا على هذه المهمة ، فإنك تشاهد استجابة فريق %(previous_team_name)s وستتلقى نفس الدرجة لهذه المهمة مثل زملائك السابقين في الفريق. لن تكون جزءًا من إرسال فريق %(team_name)s لهذا الواجب ولن تتلقى تقديرًا لإرساله.\n                                  "
 
 #: templates/openassessmentblock/response/oa_response.html:224
 msgid "We could not save your progress"


### PR DESCRIPTION
The fatal error is merely a missing `\n` at the end of a translation. Apparently, that makes `gettext` validators panic.


Also fixed it on both new and old Transifex projects. 
This is a follow up for https://github.com/openedx/openedx-translations/issues/1003 

Why a manual fix?

 - Automated updates will stay broken until this specific resource is fixed by a Transifex PR for this specific resource.

 - The timing isn't guaranteed so I've gone and fixed it myself. This should be that last fix we need to do manually if the process goes as planned.

This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
