### PR TITLE
fix: allow merging non-translations pull requests

### DIFF
--- a/.github/workflows/validate-translation-files.yml
+++ b/.github/workflows/validate-translation-files.yml
@@ -4,8 +4,6 @@ name: Validate translation PO files
 
 on:
   pull_request:
-    paths:
-      - 'translations/**'
 
 jobs:
   validate-po-files:


### PR DESCRIPTION
The `validate-translation-files.yml` workflow is now required, but it runs only on PRs in which `translations/**` have been edited.

This causes the non-translation pull requests to be blocked from merging because the `validate-translation-files.yml` won't run despite being required.

Related issues:

 - https://github.com/openedx/openedx-translations/issues/1003

This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
