### PR TITLE
fix: set max-parallel: 1 to avoid transifex (Throttled)

### DIFF
--- a/.github/workflows/sync-translations.yml
+++ b/.github/workflows/sync-translations.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         resource:
           - new_slug: edx-ora2


### PR DESCRIPTION
fix: set max-parallel: 1 to avoid transifex (Throttled)

without the limit, we'll face an exception `transifex.api.jsonapi.exceptions.JsonApiException_429_throttled`