### PR TITLE
Upgrade requirements to include the latest edx-i18n-tools

### DIFF
--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -10,7 +10,7 @@ click==8.1.7
     # via pip-tools
 importlib-metadata==6.8.0
     # via build
-packaging==23.1
+packaging==23.2
     # via build
 pip-tools==7.3.0
     # via -r requirements/pip_tools.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -16,7 +16,7 @@ certifi==2023.7.22
     # via
     #   -r requirements/translations.txt
     #   requests
-charset-normalizer==3.2.0
+charset-normalizer==3.3.0
     # via
     #   -r requirements/translations.txt
     #   requests
@@ -24,14 +24,14 @@ click==8.1.7
     # via
     #   -r requirements/translations.txt
     #   transifex-python
-coverage[toml]==7.3.1
+coverage[toml]==7.3.2
     # via pytest-cov
-django==3.2.21
+django==3.2.22
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/translations.txt
     #   edx-i18n-tools
-edx-i18n-tools==1.2.0
+edx-i18n-tools==1.3.0
     # via -r requirements/translations.txt
 exceptiongroup==1.1.3
     # via pytest
@@ -53,7 +53,11 @@ idna==3.4
     #   requests
 iniconfig==2.0.0
     # via pytest
-packaging==23.1
+lxml==4.9.3
+    # via
+    #   -r requirements/translations.txt
+    #   edx-i18n-tools
+packaging==23.2
     # via pytest
 parsimonious==0.10.0
     # via
@@ -93,7 +97,7 @@ pyyaml==6.0.1
     #   -r requirements/translations.txt
     #   edx-i18n-tools
     #   responses
-regex==2023.8.8
+regex==2023.10.3
     # via
     #   -r requirements/translations.txt
     #   parsimonious
@@ -140,7 +144,7 @@ typing-extensions==4.8.0
     # via
     #   -r requirements/translations.txt
     #   asgiref
-urllib3==1.26.16
+urllib3==1.26.17
     # via
     #   -r requirements/translations.txt
     #   requests

--- a/requirements/translations.txt
+++ b/requirements/translations.txt
@@ -10,15 +10,15 @@ asttokens==2.4.0
     # via transifex-python
 certifi==2023.7.22
     # via requests
-charset-normalizer==3.2.0
+charset-normalizer==3.3.0
     # via requests
 click==8.1.7
     # via transifex-python
-django==3.2.21
+django==3.2.22
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   edx-i18n-tools
-edx-i18n-tools==1.2.0
+edx-i18n-tools==1.3.0
     # via -r requirements/translations.in
 future==0.18.3
     # via pyseeyou
@@ -28,6 +28,8 @@ gitpython==3.1.37
     # via transifex-client
 idna==3.4
     # via requests
+lxml==4.9.3
+    # via edx-i18n-tools
 parsimonious==0.10.0
     # via pyseeyou
 path==16.7.1
@@ -46,7 +48,7 @@ pyyaml==6.0.1
     # via
     #   -r requirements/translations.in
     #   edx-i18n-tools
-regex==2023.8.8
+regex==2023.10.3
     # via parsimonious
 requests==2.31.0
     # via
@@ -71,7 +73,7 @@ transifex-python==3.4.0
     # via -r requirements/translations.in
 typing-extensions==4.8.0
     # via asgiref
-urllib3==1.26.16
+urllib3==1.26.17
     # via
     #   requests
     #   transifex-client


### PR DESCRIPTION
Upgrade requirements to include the latest `edx-i18n-tools==1.3.0`