### PR TITLE
fix: typo in the code of es_419

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ sync_translations sync_translations_github_workflow
 # Default languages for the sync_translations.py file
 # This includes languages with at least 50% translated entries.
 # This list should be all the languages Open edX supports until the migration is complete.
-export TX_LANGUAGES := ar,da,de_DE,el,es_149,es_ES,fr_CA,hi,he,id,it_IT,pt_BR,pt_PT,ru,th,tr_TR,uk,zh_CN
+export TX_LANGUAGES := ar,da,de_DE,el,es_419,es_ES,fr_CA,hi,he,id,it_IT,pt_BR,pt_PT,ru,th,tr_TR,uk,zh_CN
 
 
 piptools:


### PR DESCRIPTION
See: https://www.studiodessuantbone.com/articles/what-is-es_419/

This one reserves a `:faceplam:` emoji 😅 after https://github.com/openedx/openedx-translations/pull/1485. The title was correct, but the code wasn't.

Also, [the table](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3157524644/Translation+Working+Group#The-following-is-a-a-table-of-lanague-that-are-supporetd--last-updated) has been fixed.

This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
