### PR TITLE
fix: allow merging forks pull requests

### DIFF
--- a/.github/workflows/validate-translation-files.yml
+++ b/.github/workflows/validate-translation-files.yml
@@ -39,9 +39,9 @@ jobs:
       # This shouldn't be an issue, because bots writes directly to this repository.
       - name: Post translation validation results as a comment
         if: always()
+        continue-on-error: true  # Don't fail the build if posting the comment fails on fork pull requests.
         uses: mshick/add-pr-comment@7c0890544fb33b0bdd2e59467fbacb62e028a096
         with:
-          issue-number: ${{ github.event.pull_request.number }}
           message: |
             :white_check_mark: All translation files are valid.
 


### PR DESCRIPTION
The comment step is failing and causing pull requests from forks to be unmergeable.


This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
