### PR TITLE
feat: require the validation comment on non-fork PRs

### DIFF
--- a/.github/workflows/validate-translation-files.yml
+++ b/.github/workflows/validate-translation-files.yml
@@ -35,11 +35,10 @@ jobs:
 
           exit $has_validation_errors
 
-      # Due to GitHub Actions security reasons this will not work on fork pull requests.
-      # This shouldn't be an issue, because bots writes directly to this repository.
       - name: Post translation validation results as a comment
-        if: always()
-        continue-on-error: true  # Don't fail the build if posting the comment fails on fork pull requests.
+        # Due to GitHub Actions security reasons posting a comment isn't possible on fork pull requests.
+        # This shouldn't be an issue, because bots writes directly to this repository.
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}
         uses: mshick/add-pr-comment@7c0890544fb33b0bdd2e59467fbacb62e028a096
         with:
           message: |


### PR DESCRIPTION
This now a proper check. Finally, I've got the `if: always && ...` part right!

This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

### Testing

<details><summary>Details</summary>


 - Tested in this (fork) pull request and the step was skipped: ![image](https://github.com/openedx/openedx-translations/assets/645156/6ffeb967-4262-45cf-80fa-185bdca73ea5)


 - Tested in [another (source) pull request](https://github.com/openedx/openedx-translations/pull/1931) and the step was successful! 
![image](https://github.com/openedx/openedx-translations/assets/645156/cf1c6e2f-a182-4100-bcae-4a32685be2cf)


</details> 