### PR TITLE
fix: validate_translation works even with unicode errors

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -14,6 +14,10 @@ jobs:
       - name: clone openedx/openedx-translations
         uses: actions/checkout@v3
 
+      - name: Install gettext
+        run: |
+          sudo apt install -y gettext
+
       # Sets up Python
       - name: setup python
         uses: actions/setup-python@v4

--- a/scripts/tests/mock_translations_dir/demo-xblock/conf/locale/ar/LC_MESSAGES/django.po
+++ b/scripts/tests/mock_translations_dir/demo-xblock/conf/locale/ar/LC_MESSAGES/django.po
@@ -1,0 +1,28 @@
+# #-#-#-#-#  django.po (course-discovery)  #-#-#-#-#
+# edX translation file
+# Copyright (C) 2018 edX
+# This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
+#
+# Translators:
+# Translators:
+# Omar Al-Ithawi <i@omardo.com>, 2023
+# Brian Smith, 2023
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: edx-platform\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-10-03 00:20+0000\n"
+"PO-Revision-Date: 2023-01-26 15:39+0000\n"
+"Last-Translator: Brian Smith, 2023\n"
+"Language-Team: Arabic (https://app.transifex.com/open-edx/teams/147691/ar/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ar\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+
+#: apps/api/filters.py:47
+#, python-brace-format
+msgid "No user with the username [{username}] exists."
+msgstr "لا يوجد مستخدم بهذا الاسم [{username}]."

--- a/scripts/tests/mock_translations_dir/demo-xblock/conf/locale/de_DE/LC_MESSAGES/django.po
+++ b/scripts/tests/mock_translations_dir/demo-xblock/conf/locale/de_DE/LC_MESSAGES/django.po
@@ -1,0 +1,19 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: 0.1a\n"
+"Report-Msgid-Bugs-To: openedx-translation@googlegroups.com\n"
+"POT-Creation-Date: 2023-10-15 20:36+0000\n"
+"PO-Revision-Date: 2023-10-15 20:36:20.949198\n"
+"Last-Translator: \n"
+"Language-Team: openedx-translation <openedx-translation@googlegroups.com>\n"
+"Language: de_DE\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Generated-By: Babel 2.8.0\n"
+
+#: demo_file.py:5
+#, python-brace-format
+msgid "{action} is not a valid action."
+msgstr "{action} ist keine gültige Aktion."

--- a/scripts/tests/mock_translations_dir/demo-xblock/conf/locale/en/LC_MESSAGES/django.po
+++ b/scripts/tests/mock_translations_dir/demo-xblock/conf/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,6 @@
+msgid ""
+msgstr ""
+
+#, python-brace-format
+msgid "{action} is not a valid action."
+msgstr ""

--- a/scripts/tests/mock_translations_dir/demo-xblock/conf/locale/hi/LC_MESSAGES/django.po
+++ b/scripts/tests/mock_translations_dir/demo-xblock/conf/locale/hi/LC_MESSAGES/django.po
@@ -1,0 +1,18 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: 0.1a\n"
+"Report-Msgid-Bugs-To: openedx-translation@googlegroups.com\n"
+"POT-Creation-Date: 2023-10-15 20:36+0000\n"
+"PO-Revision-Date: 2023-10-15 20:36:20.949198\n"
+"Last-Translator: \n"
+"Language-Team: openedx-translation <openedx-translation@googlegroups.com>\n"
+"Language: de_DE\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Generated-By: Babel 2.8.0\n"
+
+#, python-brace-format
+msgid "{action} is not a valid action."
+msgstr "{कार्रवाई} एक वैध कार्रवाई नहीं है।"  # Invalid brace-format with encoding errors

--- a/scripts/tests/test_fix_transifex_resource_names.py
+++ b/scripts/tests/test_fix_transifex_resource_names.py
@@ -1,7 +1,7 @@
 """
 Tests for fix_transifex_resource_names.py.
 """
-import unittest
+
 from unittest.mock import MagicMock
 from ..fix_transifex_resource_names import get_repo_slug_from_resource
 

--- a/scripts/tests/test_sync_translations.py
+++ b/scripts/tests/test_sync_translations.py
@@ -3,7 +3,6 @@ Tests for sync_translations.py
 """
 import types
 
-import pytest
 import responses
 from transifex.api import transifex_api, Project
 from transifex.api.jsonapi import Resource

--- a/scripts/tests/test_validate_translation_files.py
+++ b/scripts/tests/test_validate_translation_files.py
@@ -1,0 +1,67 @@
+"""
+Tests for the validate_translation_files.py script.
+"""
+
+import os.path
+
+from ..validate_translation_files import (
+    get_translation_files,
+    main,
+)
+
+SCRIPT_DIR = os.path.dirname(__file__)
+
+
+def test_get_translation_files():
+    """
+    Ensure `get_translation_files` skips the source translation files and non-po files.
+    """
+    mock_translations_dir = os.path.join(SCRIPT_DIR, 'mock_translations_dir')
+    po_files_sorted = sorted(get_translation_files(mock_translations_dir))
+    relative_po_files = [
+        os.path.relpath(po_file, SCRIPT_DIR)
+        for po_file in po_files_sorted
+    ]
+
+    assert relative_po_files == [
+        'mock_translations_dir/demo-xblock/conf/locale/ar/LC_MESSAGES/django.po',
+        'mock_translations_dir/demo-xblock/conf/locale/de_DE/LC_MESSAGES/django.po',
+        'mock_translations_dir/demo-xblock/conf/locale/hi/LC_MESSAGES/django.po',
+    ]
+
+
+def test_main_on_invalid_files(capsys):
+    """
+    Integration test for the `main` function on some invalid files.
+    """
+    mock_translations_dir = os.path.join(SCRIPT_DIR, 'mock_translations_dir')
+    exit_code = main(mock_translations_dir)
+    out, err = capsys.readouterr()
+
+    assert 'VALID:' in out, 'Valid files should be printed in stdout'
+    assert 'de_DE/LC_MESSAGES/django.po' in out, 'German translation file should be found valid'
+    assert 'ar/LC_MESSAGES/django.po' in out, 'Arabic translation file should be found valid'
+    assert 'hi/LC_MESSAGES/django.po' not in out, 'Invalid file should be printed in stderr'
+    assert 'en/LC_MESSAGES/django.po' not in out, 'Source file should not be validated'
+
+    assert 'INVALID:' in err
+    assert 'hi/LC_MESSAGES/django.po' in err
+    assert '\'msgstr\' is not a valid Python brace format string, unlike \'msgid\'' in err
+    assert 'FAILURE: Some translations are invalid.' in err
+
+    assert exit_code == 1, 'Should fail due to invalid hi/LC_MESSAGES/django.po file'
+
+
+def test_main_on_valid_files(capsys):
+    """
+    Integration test for the `main` function but only for the Arabic translations which is valid.
+    """
+    mock_translations_dir = os.path.join(SCRIPT_DIR, 'mock_translations_dir/demo-xblock/conf/locale/ar')
+    exit_code = main(mock_translations_dir)
+    out, err = capsys.readouterr()
+
+    assert 'VALID:' in out, 'Valid files should be printed in stdout'
+    assert 'ar/LC_MESSAGES/django.po' in out, 'Arabic translation file is valid'
+    assert 'SUCCESS: All translation files are valid.' in out
+    assert not err.strip(), 'The stderr should be empty'
+    assert exit_code == 0, 'Should succeed due in validating the ar/LC_MESSAGES/django.po file'


### PR DESCRIPTION
### Changes
 - fixes the exception shown in the comment: https://github.com/openedx/openedx-translations/pull/1611#issuecomment-1770897544:
   ```
       Traceback (most recent call last):
      File 
    "/home/runner/work/openedx-translations/openedx-translations/scripts/validate_translation_files.py",
     line 70, in <module>
        main()
      File 
    "/home/runner/work/openedx-translations/openedx-translations/scripts/validate_translation_files.py",
     line 47, in main
        result = validate_translation_file(po_file)
      File 
    "/home/runner/work/openedx-translations/openedx-translations/scripts/validate_translation_files.py",
     line 27, in validate_translation_file
        completed_process = subprocess.run(
      File "/usr/lib/python3.10/subprocess.py", line 505, in run
        stdout, stderr = process.communicate(input, timeout=timeout)
      File "/usr/lib/python3.10/subprocess.py", line 1154, in communicate
        stdout, stderr = self._communicate(input, endtime, timeout)
      File "/usr/lib/python3.10/subprocess.py", line 2063, in _communicate
        stderr = self._translate_newlines(stderr,
      File "/usr/lib/python3.10/subprocess.py", line 1031, in _translate_newlines
        data = data.decode(encoding, errors)
    UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe0 in position 340: invalid continuation byte
    ```
 - added tests to ensure the file is covered
 - redirected the stderr output to be printed in the last step for easy debugging
 - cleanup unused imports in other test files

### Testing

 - [x] Verified locally on both broken and correct branches

### Refs

This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
