### PR TITLE
feat: misc fixes for FC-0012 scripting

### DIFF
--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -15,26 +15,15 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: merge pull request
-        uses: nick-fields/retry@v2
-        id: mergePR
+
+      - name: Auto-merge pull request
         env:
           # secrets can't be used in job conditionals, so we set them to env here
           TRANSIFEX_APP_ACTOR_NAME: "${{ secrets.TRANSIFEX_APP_ACTOR_NAME }}"
           TRANSIFEX_APP_ACTOR_ID: "${{ secrets.TRANSIFEX_APP_ACTOR_ID }}"
           # This token requires Write access to the openedx-translations repo
           GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.number }}
         if: "${{ github.actor == env.TRANSIFEX_APP_ACTOR_NAME && github.actor_id == env.TRANSIFEX_APP_ACTOR_ID }}"
-        with:
-          retry_wait_seconds: 60
-          max_attempts: 5
-          timeout_minutes: 15
-          retry_on: error
-          command: |
-            # Attempt to merge the PR
-            gh pr merge ${{ github.head_ref }} --rebase --auto
-
-            # The `fromdate | todate` are used merge to validate that `mergedAt` isn't null
-            # therefore verifying that the pull request was merged successfully.
-            gh pr view "$PR_NUMBER" --json mergedAt --jq '.mergedAt | fromdate | todate'
+        run: |
+          # Add the pull request to the merge queue with --rebase commit strategy
+          gh pr merge ${{ github.head_ref }} --rebase --auto

--- a/.github/workflows/validate-translation-files.yml
+++ b/.github/workflows/validate-translation-files.yml
@@ -62,7 +62,7 @@ jobs:
             :warning: There are errors in the translation files:
 
             ```
-            ${{ steps.validate_translation_files.outputs.VALIDATION_ERRORS }}
+            ${{ steps.validate_translation_files.outputs.VALIDATION_ERRORS || 'No errors were reported.' }}
             ```
 
             This comment has been posted by the `validate-translation-files.yml` GitHub Actions workflow.

--- a/scripts/tests/test_validate_translation_files.py
+++ b/scripts/tests/test_validate_translation_files.py
@@ -3,10 +3,11 @@ Tests for the validate_translation_files.py script.
 """
 
 import os.path
+import re
 
 from ..validate_translation_files import (
     get_translation_files,
-    main,
+    validate_translation_files,
 )
 
 SCRIPT_DIR = os.path.dirname(__file__)
@@ -35,7 +36,7 @@ def test_main_on_invalid_files(capsys):
     Integration test for the `main` function on some invalid files.
     """
     mock_translations_dir = os.path.join(SCRIPT_DIR, 'mock_translations_dir')
-    exit_code = main(mock_translations_dir)
+    exit_code = validate_translation_files(mock_translations_dir)
     out, err = capsys.readouterr()
 
     assert 'VALID:' in out, 'Valid files should be printed in stdout'
@@ -44,8 +45,7 @@ def test_main_on_invalid_files(capsys):
     assert 'hi/LC_MESSAGES/django.po' not in out, 'Invalid file should be printed in stderr'
     assert 'en/LC_MESSAGES/django.po' not in out, 'Source file should not be validated'
 
-    assert 'INVALID:' in err
-    assert 'hi/LC_MESSAGES/django.po' in err
+    assert re.match(r'INVALID: .*hi/LC_MESSAGES/django.po', err)
     assert '\'msgstr\' is not a valid Python brace format string, unlike \'msgid\'' in err
     assert 'FAILURE: Some translations are invalid.' in err
 
@@ -57,7 +57,7 @@ def test_main_on_valid_files(capsys):
     Integration test for the `main` function but only for the Arabic translations which is valid.
     """
     mock_translations_dir = os.path.join(SCRIPT_DIR, 'mock_translations_dir/demo-xblock/conf/locale/ar')
-    exit_code = main(mock_translations_dir)
+    exit_code = validate_translation_files(mock_translations_dir)
     out, err = capsys.readouterr()
 
     assert 'VALID:' in out, 'Valid files should be printed in stdout'

--- a/scripts/validate_translation_files.py
+++ b/scripts/validate_translation_files.py
@@ -1,7 +1,12 @@
-import sys
+"""
+Validate translation files using GNU gettext `msgfmt` command.
+"""
+
+import argparse
 import os
 import os.path
 import subprocess
+import sys
 
 
 def get_translation_files(translation_directory):
@@ -39,7 +44,9 @@ def validate_translation_file(po_file):
     }
 
 
-def main(translations_dir='translations'):
+def validate_translation_files(
+    translations_dir='translations',
+):
     """
     Run GNU gettext `msgfmt` and print errors to stderr.
 
@@ -81,5 +88,14 @@ def main(translations_dir='translations'):
     return exit_code
 
 
+def main():  # pragma: no cover
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--dir', action='store', type=str, default='translations')
+    args = parser.parse_args()
+    sys.exit(validate_translation_files(
+        translations_dir=args.dir,
+    ))
+
+
 if __name__ == '__main__':
-    sys.exit(main())  # pragma: no cover
+    main()  # pragma: no cover


### PR DESCRIPTION
- fix: avoid failing the automerge-transifex-app-prs.yml 
- fix: add default failure message if nothing is printed on stdout
- chore: use argparse on validate_translation_files.py 


This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
