### PR TITLE
fix: avoid overriding manual edits for newer entries

### DIFF
--- a/.github/workflows/sync-translations.yml
+++ b/.github/workflows/sync-translations.yml
@@ -44,10 +44,6 @@ jobs:
             old_slug: course_discovery
             old_project_slug: edx-platform
 
-          - new_slug: course-discovery
-            old_slug: course_discovery
-            old_project_slug: edx-platform
-
           - new_slug: course-discovery-js
             old_slug: course_discovery-js
             old_project_slug: edx-platform
@@ -115,6 +111,56 @@ jobs:
           - new_slug: paragon
             old_slug: paragon
             old_project_slug: edx-platform
+
+          # Start: edx-platform repo resources
+          # The edx-platform repo resources has been consolidated into a two resources
+          #   - https://github.com/openedx/edx-platform/blob/master/docs/decisions/0018-standarize-django-po-files.rst
+
+          - new_slug: edx-platform
+            old_slug: django-partial
+            old_project_slug: edx-platform
+
+          - new_slug: edx-platform
+            old_slug: django-studio
+            old_project_slug: edx-platform
+
+          - new_slug: edx-platform
+            old_slug: edx_proctoring_proctortrack
+            old_project_slug: edx-platform
+
+          - new_slug: edx-platform
+            old_slug: mako
+            old_project_slug: edx-platform
+
+          - new_slug: edx-platform
+            old_slug: mako-studio
+            old_project_slug: edx-platform
+
+          - new_slug: edx-platform
+            old_slug: wiki
+            old_project_slug: edx-platform
+
+          - new_slug: edx-platform-js
+            old_slug: underscore
+            old_project_slug: edx-platform
+
+          - new_slug: edx-platform-js
+            old_slug: djangojs-studio
+            old_project_slug: edx-platform
+
+          - new_slug: edx-platform-js
+            old_slug: underscore-studio
+            old_project_slug: edx-platform
+
+          - new_slug: edx-platform-js
+            old_slug: djangojs-account-settings-view
+            old_project_slug: edx-platform
+
+          - new_slug: edx-platform-js
+            old_slug: djangojs-partial
+            old_project_slug: edx-platform
+
+          # End: edx-platform repo resources
 
     steps:
       - uses: actions/checkout@v3

--- a/scripts/sync_translations.py
+++ b/scripts/sync_translations.py
@@ -181,7 +181,7 @@ class Command:
         """
         Run the script from a GitHub Actions migrate-from-transifex-old-project.yml workflow file.
         """
-        pairs_list = workflow_configs['jobs']['migrate-translations']['strategy']['matrix']['batch']
+        pairs_list = workflow_configs['jobs']['migrate-translations']['strategy']['matrix']['resource']
 
         print('Verifying existence of resource pairs...')
         for pair in pairs_list:

--- a/scripts/tests/test_sync_translations.py
+++ b/scripts/tests/test_sync_translations.py
@@ -14,7 +14,11 @@ from transifex.api.jsonapi import Resource
 from transifex.api.jsonapi.auth import BearerAuthentication
 
 from . import response_data
-from ..sync_translations import Command, ORGANIZATION_SLUG
+from ..sync_translations import (
+    Command,
+    ORGANIZATION_SLUG,
+    parse_tx_date,
+)
 
 HOST = transifex_api.HOST
 
@@ -32,6 +36,70 @@ def sync_command(**kwargs):
     result = Command(**command_args)
     result.tx_api.make_auth_headers = BearerAuthentication('dummy-token')
     return result
+
+
+@dataclass
+class ResourceStringMock:
+    """
+    String entry in Transifex.
+
+    Mock class for the transifex.api.ResourceString class.
+    """
+    key: str
+    context: str = ''
+
+
+@dataclass
+class ResourceTranslationMock:
+    """
+    Translation for an entry in Transifex.
+
+    Mock class for the transifex.api.ResourceTranslation class.
+    """
+    resource_string: ResourceStringMock
+    strings: dict
+    reviewed: bool
+    proofread: bool
+    datetime_translated: str
+
+    _updates: dict = None  # Last updates applied via `save()`
+
+    def save(self, **updates):
+        """
+        Mock ResourceTranslation.save() method.
+        """
+        self._updates = updates
+
+    @property
+    def updates(self):
+        """
+        Return the last updates applied via `save()`.
+        """
+        return self._updates
+
+    @classmethod
+    def factory(
+        cls,
+        key='key',
+        context='',
+        translation: Union[str, None] = 'dummy translation',
+        **kwargs
+    ):
+        mock_kwargs = dict(
+            resource_string=ResourceStringMock(
+                key=key,
+                context=context
+            ),
+            strings={
+                key: translation,
+            },
+            reviewed=False,
+            proofread=False,
+            datetime_translated='2021-01-01T00:00:00Z',
+        )
+
+        mock_kwargs.update(kwargs)
+        return cls(**mock_kwargs)
 
 
 @responses.activate
@@ -96,3 +164,153 @@ def test_get_translations():
     items = list(data)
     assert len(items) == 1
     assert items[0].id == response_data.RESPONSE_GET_LANGUAGE['data'][0]['id']
+
+
+def test_translations_entry_update_empty_translation():
+    """
+    Test updating an entry from old project where `current_translation` is empty.
+    """
+    command = sync_command(dry_run=False)
+
+    translation_from_old_project = ResourceTranslationMock.factory(
+        key='test_key',
+        translation='old translation',
+        reviewed=True,
+        datetime_translated='2023-01-01T00:00:00Z',
+    )
+
+    # Current translation is empty
+    current_translation = ResourceTranslationMock.factory(
+        key='test_key',
+        translation=None,
+        datetime_translated=None,
+    )
+
+    status = command.sync_translation_entry(
+        translation_from_old_project, current_translation
+    )
+
+    assert status == 'updated'
+    assert current_translation.updates == {
+        'strings': {
+            'test_key': 'old translation'
+        },
+        'reviewed': True,
+    }
+
+
+@pytest.mark.parametrize(
+    'old_project_date, current_translation_date, new_translation_str',
+    [
+        # As long as the current translation is _not_ more recent, it should be updated
+        (None, '2023-01-01T00:00:00Z', None),
+        (None, '2023-01-01T00:00:00Z', 'some translation'),
+        ('2023-01-01T00:00:00Z', '2023-01-01T00:00:00Z', 'some translation'),  # Same date
+        ('2023-01-01T00:00:00Z', '2021-01-01T00:00:00Z', 'some translation'),  # New project has newer date
+        ('2023-01-01T00:00:00Z', None, 'some translation'),
+        ('2023-01-01T00:00:00Z', None, None),
+    ]
+)
+def test_translations_entry_update_translation(old_project_date, current_translation_date, new_translation_str):
+    """
+    Test updating an entry from old project where `current_translation` is has outdated translation.
+    """
+    command = sync_command(dry_run=False)
+
+    translation_from_old_project = ResourceTranslationMock.factory(
+        key='test_key',
+        translation='old translation',
+        reviewed=True,
+        datetime_translated=old_project_date,
+    )
+
+    current_translation = ResourceTranslationMock.factory(
+        key='test_key',
+        translation=new_translation_str,
+        datetime_translated=current_translation_date,
+    )
+
+    status = command.sync_translation_entry(
+        translation_from_old_project, current_translation
+    )
+
+    assert status == 'updated'
+    assert current_translation.updates == {
+        'strings': {
+            'test_key': 'old translation'
+        },
+        'reviewed': True,
+    }
+
+
+def test_translations_entry_more_recent_translation():
+    """
+    Verify that the more recent translations in the open-edx/openedx-translations project are not overridden.
+    """
+    command = sync_command(dry_run=False)
+
+    translation_from_old_project = ResourceTranslationMock.factory(
+        key='test_key',
+        translation='one translation',
+        reviewed=True,
+        datetime_translated='2019-01-01T00:00:00Z',
+    )
+
+    # Current translation is empty
+    current_translation = ResourceTranslationMock.factory(
+        key='test_key',
+        translation='more recent translation',
+        datetime_translated='2023-01-01T00:00:00Z',
+    )
+
+    status = command.sync_translation_entry(
+        translation_from_old_project, current_translation
+    )
+
+    assert status == 'skipped'
+    assert not current_translation.updates, 'save() should not be called'
+
+
+def test_translations_entry_dry_run():
+    """
+    Verify that --dry-run option skips the save() call.
+    """
+    command = sync_command(dry_run=True)
+
+    translation_from_old_project = ResourceTranslationMock.factory(
+        key='test_key',
+        translation='old translation',
+        reviewed=True,
+        datetime_translated='2023-01-01T00:00:00Z',
+    )
+
+    current_translation = ResourceTranslationMock.factory(
+        key='test_key',
+        translation=None,
+        datetime_translated=None,
+    )
+
+    status = command.sync_translation_entry(
+        translation_from_old_project, current_translation
+    )
+
+    assert status == 'updated-dry-run'
+    assert not current_translation.updates, 'save() should not be called in --dry-run mode'
+
+
+@pytest.mark.parametrize(
+    "date_str, parse_result, test_message",
+    [
+        (None, None, 'None cannot be parsed'),
+        ('2023-01-01T00:00:00Z', datetime(2023, 1, 1, 0, 0, tzinfo=timezone.utc),
+         'Z suffix is replaced with the explict "+00:00" timezone'),
+        ('2023-01-01T00:00:00', datetime(2023, 1, 1, 0, 0),
+         'If there is no Z suffix, no timezone is added'),
+    ]
+)
+def test_parse_tx_date(date_str, parse_result, test_message):
+    """
+    Tests for parse_tx_date() helper function.
+    """
+    assert parse_tx_date(date_str) == parse_result, test_message
+

--- a/scripts/tests/test_sync_translations.py
+++ b/scripts/tests/test_sync_translations.py
@@ -1,9 +1,14 @@
 """
 Tests for sync_translations.py
 """
+from dataclasses import dataclass
+from datetime import datetime, timezone
 import types
+from typing import Union
 
+import pytest
 import responses
+
 from transifex.api import transifex_api, Project
 from transifex.api.jsonapi import Resource
 from transifex.api.jsonapi.auth import BearerAuthentication
@@ -14,14 +19,17 @@ from ..sync_translations import Command, ORGANIZATION_SLUG
 HOST = transifex_api.HOST
 
 
-def sync_command():
-    result = Command(
-        argv=[],
-        tx_api=transifex_api,
-        environ={
+def sync_command(**kwargs):
+    command_args = {
+        'tx_api': transifex_api,
+        'dry_run': True,
+        'simulate_github_workflow': False,
+        'environ': {
             'TX_API_TOKEN': 'dummy-token'
         }
-    )
+    }
+    command_args.update(kwargs)
+    result = Command(**command_args)
     result.tx_api.make_auth_headers = BearerAuthentication('dummy-token')
     return result
 


### PR DESCRIPTION
### Problem
We've done about 200 manual fix on the https://app.transifex.com/open-edx/openedx-translations/ to fix translation validation issues in PRs such as https://github.com/openedx/openedx-translations/pull/1577/commits/d1ddaa7fef356de96608128c151570e766f4cf1e. 

Those changes would be overridden on the next sync and needs to be fixed again.

For more information, please check [this Slack Thread](https://openedx.slack.com/archives/C04R6TUJB7T/p1699457188895449) about the problem.

### Solution

This pull request will only update the translation string if new translation is found:

```
newer_translation_found = new_project_translation_time > old_project_translation_time
```


### TODO
 - [x] Implement and test
 - [x] Add unit tests
 - [x] Test locally: ```$ make SYNC_ARGS=--dry-run TX_NEW_SLUG=course-discovery TX_OLD_SLUG=course_discovery TX_OLD_PROJECT_SLUG=edx-platform TX_LANGUAGES=es_419 sync_translations```
 - [x] Run sync again and ensure it's working as expected, without edx-platform repo resources
 - [ ] Run sync again and ensure it's working as expected, with edx-platform repo resources
 - [ ] Merge and unblock https://github.com/openedx/edx-platform/pull/33502

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).
