### PR TITLE
feat: Add edx-enterprise to the translation pipeline

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -37,6 +37,7 @@ jobs:
               'DoneXBlock',
               'edx-ace',
               'edx-bulk-grades',
+              'edx-enterprise',
               'edx-ora2',
               'edx-proctoring',
               'FeedbackXBlock',


### PR DESCRIPTION
feat: Add [edx-enterprise](https://github.com/openedx/edx-enterprise) to the translation pipeline

**IMPORTANT:** This PR needs https://github.com/openedx/edx-enterprise/pull/1751 before it's merged.

- [x] Verified in a test PR in a forked repo: https://github.com/Zeit-Labs/openedx-translations/pull/88/files#r1390383474

Refs:
This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
see details [here](https://github.com/openedx/xblock-submit-and-compare/pull/96)