### PR TITLE
fix: ensure we have an empty string instead of null for `selectedRepo`

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -26,7 +26,7 @@ jobs:
           script: |
             // Need to use a workaround until https://github.com/actions/toolkit/issues/1576 is fixed
             // const selectedRepo = core.getInput('repo');
-            const selectedRepo = ${{ toJSON(github.event.inputs.repo) }};
+            const selectedRepo = ${{ toJSON(github.event.inputs.repo) }} ?? '';
 
             const allPythonRepos = [
               'AudioXBlock',


### PR DESCRIPTION
When running the `extract-translation-source-files` workflow via dispatch `selectedRepo` pulls from `inputs.repo` which is always a string (but can be an empty string).

The logic throughout the rest of the workflow assumes an empty string, but fails with null or undefined.

This just add a null coalesce that defaults `selectedRepo` to an empty string so the rest of the logic works.