### PR TITLE
feat: Add ecommerce to the translation pipeline

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -35,6 +35,7 @@ jobs:
               'credentials',
               'credentials-themes',
               'DoneXBlock',
+              'ecommerce',
               'edx-ace',
               'edx-bulk-grades',
               'edx-ora2',
@@ -214,7 +215,8 @@ jobs:
           cd translations/${{ matrix.repo }}
           # finds the directory containing the english locale usually located in
           # */*/conf/locale/en
-          EN_DIR=$(find . -type d -regex ".+conf\/locale\/en$")
+          # but also exclude any hidden directories that might exist for some reason
+          EN_DIR=$(find . -type d -not -path '*/.*' -regex ".+conf\/locale\/en$")
           # If the directory is not found, exit with an error. This can happen if we add a repository that doesn't
           # comply with OEP-58, or it still doesn't have any translations yet
           if [ -z "$EN_DIR" ]; then


### PR DESCRIPTION
feat: Add [ecommerce](https://github.com/openedx/ecommerce) to the translation pipeline

- [x] Verified in a test PR in a forked repo: https://github.com/Zeit-Labs/openedx-translations/pull/97

Refs:
This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
see details [here](https://github.com/openedx/xblock-submit-and-compare/pull/96)