### PR TITLE
fix: revert: avoid failing the automerge-transifex-app-prs.yml 

### DIFF
--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -27,7 +27,7 @@ jobs:
           PR_NUMBER: ${{ github.event.number }}
         if: "${{ github.actor == env.TRANSIFEX_APP_ACTOR_NAME && github.actor_id == env.TRANSIFEX_APP_ACTOR_ID }}"
         with:
-          retry_wait_seconds: 60
+          retry_wait_seconds: 180
           max_attempts: 5
           timeout_minutes: 15
           retry_on: error

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -35,6 +35,12 @@ jobs:
             # Attempt to merge the PR
             gh pr merge ${{ github.head_ref }} --rebase --auto
 
-            # The `fromdate | todate` are used merge to validate that `mergedAt` isn't null
-            # therefore verifying that the pull request was merged successfully.
-            gh pr view "$PR_NUMBER" --json mergedAt --jq '.mergedAt | fromdate | todate'
+            MERGE_DATE="$(gh pr view "$PR_NUMBER" --json mergedAt --jq '.mergedAt')"
+
+            if [ -n "$MERGE_DATE" ]; then
+              echo "Success: PR merged at '$MERGE_DATE'"
+              exit 0
+            else
+              echo "PR not merged yet, retrying via 'nick-fields/retry'..."
+              exit 1
+            fi

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -15,15 +15,26 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - name: Auto-merge pull request
+      - name: merge pull request
+        uses: nick-fields/retry@v2
+        id: mergePR
         env:
           # secrets can't be used in job conditionals, so we set them to env here
           TRANSIFEX_APP_ACTOR_NAME: "${{ secrets.TRANSIFEX_APP_ACTOR_NAME }}"
           TRANSIFEX_APP_ACTOR_ID: "${{ secrets.TRANSIFEX_APP_ACTOR_ID }}"
           # This token requires Write access to the openedx-translations repo
           GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
         if: "${{ github.actor == env.TRANSIFEX_APP_ACTOR_NAME && github.actor_id == env.TRANSIFEX_APP_ACTOR_ID }}"
-        run: |
-          # Add the pull request to the merge queue with --rebase commit strategy
-          gh pr merge ${{ github.head_ref }} --rebase --auto
+        with:
+          retry_wait_seconds: 60
+          max_attempts: 5
+          timeout_minutes: 15
+          retry_on: error
+          command: |
+            # Attempt to merge the PR
+            gh pr merge ${{ github.head_ref }} --rebase --auto
+
+            # The `fromdate | todate` are used merge to validate that `mergedAt` isn't null
+            # therefore verifying that the pull request was merged successfully.
+            gh pr view "$PR_NUMBER" --json mergedAt --jq '.mergedAt | fromdate | todate'


### PR DESCRIPTION
This reverts commit https://github.com/openedx/openedx-translations/commit/854ceef60fdeb48cab6087df34f7a1c9722632b5, but increase `retry_wait_seconds` to 180 and use bash if-statement.

There has been new failures which prevented such as:

> GraphQL: Pull request Pull request is in unstable status (enablePullRequestAutoMerge)

as well as the interminent error of:

> auto-merge was automatically disabled yesterday
> Base branch was modified

This effectively brings back both https://github.com/openedx/openedx-translations/pull/222 and https://github.com/openedx/openedx-translations/pull/225.

### Refs

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).
