### PR TITLE
fix: rename fix-transifex-resource-names.yml titles

### DIFF
--- a/.github/workflows/fix-transifex-resource-names.yml
+++ b/.github/workflows/fix-transifex-resource-names.yml
@@ -1,6 +1,6 @@
 # This workflow runs fix-transifex-resource-names.py nightly
 
-name: Set the openedx-translations to readable resource names
+name: Fix Transifex resource names and slugs
 
 on:
   workflow_dispatch:  # by request
@@ -13,7 +13,7 @@ on:
     - cron: '0 0 1 * *'
 
 jobs:
-  python-translations:
+  resource-names:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
It puzzles me every time I try to locate the workflow in the GitHub Actions UI.


This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).
