### PR TITLE
chore: mark this repo as production | FC-0012

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -13,4 +13,4 @@ metadata:
 spec:
   owner: domain-translations
   type: 'library'
-  lifecycle: 'experimental'
+  lifecycle: 'production'


### PR DESCRIPTION
This is going to be used in production by Redwood. I'm making this pull request to mark it appropriately.

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).
