### PR TITLE
feat: Enabled translations for frontend-app-learner-portal-enterprise

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -87,6 +87,7 @@ jobs:
               'frontend-platform',
               'paragon',
               'studio-frontend',
+              'frontend-app-learner-portal-enterprise',
             ];
 
             const allGenericRepos = [
@@ -313,7 +314,6 @@ jobs:
       matrix:
         # repos missing extract_translations target in makefile:
         # * frontend-enterprise?
-        # * frontend-app-learner-portal-enterprise
         # * frontend-build?
         # * frontend-app-learner-portal-programs
         # * frontend-component-cookie-policy-banner

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ htmlcov
 
 # msgfmt sometimes leaves these behind in the root directory
 /*.mo
+
+# IntelliJ IDE files
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,3 @@ htmlcov
 
 # msgfmt sometimes leaves these behind in the root directory
 /*.mo
-
-# IntelliJ IDE files
-.idea/


### PR DESCRIPTION
__Jira Ticket:__ [ENT-8221](https://2u-internal.atlassian.net/browse/ENT-8221)

__Description:__
This PR enables translations for `frontend-app-learner-portal-enterprise` repo. The required commands have already been added to the `Makefile` of `frontend-app-learner-portal-enterprise` (https://github.com/openedx/frontend-app-learner-portal-enterprise/blob/master/Makefile#L44-L67).

**Note:** I was not able to test this via the instructions in https://docs.openedx.org/en/latest/developers/how-tos/enable-translations-new-repo.html#id7 However, I have tested the flow using my own Transifex account.