### PR TITLE
fix: permissions to auto-merge pull requests | FC-0012

### DIFF
--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   automerge-transifex-app-pr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     # Merges the pull request
     steps:
       - name: clone repository


### PR DESCRIPTION
otherwise it'll fail with the error message below:

    GraphQL: edx-transifex-bot does not have the correct permissions to 
    execute `EnablePullRequestAutoMerge` (enablePullRequestAutoMerge)

Apparently this error is due to a GitHub update since 2 weeks ago. All pending PRs since 2 weeks face this error and aren't merged:

 - https://github.com/openedx/openedx-translations/pull/3811


This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).
