### PR TITLE
fix: Added frontend-app-learner-portal-enterprise to transifex.yml

### DIFF
--- a/transifex.yml
+++ b/transifex.yml
@@ -267,6 +267,13 @@ git:
     source_file: translations/frontend-platform/src/i18n/transifex_input.json
     translation_files_expression: 'translations/frontend-platform/src/i18n/messages/<lang>.json'
 
+  # frontend-app-learner-portal-enterprise
+  - filter_type: file
+    file_format: KEYVALUEJSON
+    source_language: en
+    source_file: translations/frontend-app-learner-portal-enterprise/src/i18n/transifex_input.json
+    translation_files_expression: 'translations/frontend-app-learner-portal-enterprise/src/i18n/messages/<lang>.json'
+
   # paragon
   - filter_type: file
     file_format: KEYVALUEJSON


### PR DESCRIPTION
This PR adds `frontend-app-learner-portal-enterprise` to `transifex.yml` so that translations for this repo start syncing with Transifex.