### PR TITLE
fix: add frontend-app-admin-portal to transifex.yml

### DIFF
--- a/transifex.yml
+++ b/transifex.yml
@@ -120,6 +120,13 @@ git:
     source_file: translations/frontend-app-account/src/i18n/transifex_input.json
     translation_files_expression: 'translations/frontend-app-account/src/i18n/messages/<lang>.json'
 
+  # frontend-app-admin-portal
+  - filter_type: file
+    file_format: KEYVALUEJSON
+    source_language: en
+    source_file: translations/frontend-app-admin-portal/src/i18n/transifex_input.json
+    translation_files_expression: 'translations/frontend-app-admin-portal/src/i18n/messages/<lang>.json'
+
   # frontend-app-authn
   - filter_type: file
     file_format: KEYVALUEJSON


### PR DESCRIPTION
This entry has been missing so translations wasn't making it into this repo from Transifex.

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).
