### PR TITLE
feat: add openedx-app-ios with support for pre-extract step | FC-55

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -94,7 +94,12 @@ jobs:
             const allGenericRepos = [
               {
                 repo: 'tutor-contrib-aspects',
-                transifex_file_path: 'transifex_input.yaml'
+                transifex_file_path: 'transifex_input.yaml',
+              },
+              {
+                repo: 'openedx-app-ios',
+                transifex_file_path: 'I18N/I18N/en.lproj/Localizable.strings',
+                before_extract: 'make translation_requirements',
               },
             ]
 
@@ -416,6 +421,13 @@ jobs:
       # Installs Python requirements from translations.txt
       - name: install requirements
         run: pip install -r requirements/translations.txt
+
+      - name: run optional pre-extraction step
+        if: "${{ matrix.repository_config.before_extract }}"
+        run: |
+          # If the repository has additional requirements or processing steps run them
+          cd translations/${{ matrix.repository_config.repo }}
+          ${{ matrix.repository_config.before_extract }}
 
       # Extracts the translation source files
       - name: extract translation source files

--- a/transifex.yml
+++ b/transifex.yml
@@ -296,6 +296,14 @@ git:
     source_file_dir: translations/platform-plugin-aspects/platform_plugin_aspects/conf/locale/en/
     translation_files_expression: 'translations/platform-plugin-aspects/platform_plugin_aspects/conf/locale/<lang>/'
 
+  # openedx-app-ios
+  - filter_type: file
+    file_format: STRINGS
+    source_file_extension: strings
+    source_language: en
+    source_file_dir: translations/openedx-app-ios/I18N/I18N/en.lproj/Localizable.strings
+    translation_files_expression: 'translations/openedx-app-ios/I18N/I18N/<lang>.lproj/Localizable.strings'
+
   # RecommenderXBlock
   - filter_type: dir
     file_format: PO


### PR DESCRIPTION
### Changes
- Add https://github.com/openedx/openedx-app-ios to the list of supported repositories.
- Added support for optional translation requirements through `before_translate` step.

### TODO

- [x] Get the https://github.com/openedx/openedx-app-ios/pull/422 merged
- [x] Test on our fork: Works okay https://github.com/Zeit-Labs/openedx-translations/blob/2cdaf2cb4bcf227a58669affb3bfa35dda17ecfd/translations/openedx-app-ios/I18N/I18N/en.lproj/Localizable.strings#L1-L110

### Refs
This pull request is part of the [FC-0055 project](https://openedx.atlassian.net/l/cp/nSkaHb7G) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html) for mobile apps.
