### PR TITLE
fix: TRANSIFEX_API_TOKEN name corrected

### DIFF
--- a/scripts/release_project_sync.py
+++ b/scripts/release_project_sync.py
@@ -54,7 +54,7 @@ class Command:
         """
         Get openedx-translations projects from Transifex.
         """
-        tx_api_token = self.environ.get('TX_API_TOKEN')
+        tx_api_token = self.environ.get('TRANSIFEX_API_TOKEN')
         if not tx_api_token:
             config = configparser.ConfigParser()
             config.read(expanduser('~/.transifexrc'))

--- a/scripts/tests/test_release_project_sync.py
+++ b/scripts/tests/test_release_project_sync.py
@@ -14,7 +14,6 @@ from transifex.api.jsonapi.auth import BearerAuthentication
 from . import response_data
 from ..release_project_sync import (
     Command,
-    ORGANIZATION_SLUG,
 )
 
 HOST = transifex_api.HOST
@@ -28,7 +27,7 @@ def sync_command(**kwargs):
         'resource': '',
         'release_name': 'zebrawood',
         'environ': {
-            'TX_API_TOKEN': 'dummy-token'
+            'TRANSIFEX_API_TOKEN': 'dummy-token'
         }
     }
     command_args.update(kwargs)


### PR DESCRIPTION
Fix error in environment variable name that breaks the CI builds on GitHub Actions.




### Fixes
Error in CI builds: https://github.com/openedx/openedx-translations/actions/runs/9410676907/job/25922716879

```
Notice:  A new release of pip is available: 23.0.1 -> 24.0
Notice:  To update, run: pip install --upgrade pip
Traceback (most recent call last):
  File "./scripts/release_project_sync.py", line 292, in <module>
    main()  # pragma: no cover
  File "./scripts/release_project_sync.py", line 288, in main
    command.run()
  File "./scripts/release_project_sync.py", line 227, in run
    main_project = self.get_transifex_project(project_slug=MAIN_PROJECT_SLUG)
  File "./scripts/release_project_sync.py", line 61, in get_transifex_project
    tx_api_token = config['https://www.transifex.com']['password']
  File "/opt/hostedtoolcache/Python/3.8.[18](https://github.com/openedx/openedx-translations/actions/runs/9410676907/job/25922716879#step:4:19)/x64/lib/python3.8/configparser.py", line 960, in __getitem__
    raise KeyError(key)
KeyError: 'https://www.transifex.com'
Error: Process completed with exit code 1.
```

