### PR TITLE
feat: add mobile apps and with support for pre-extract step | FC-55

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -95,7 +95,19 @@ jobs:
             const allGenericRepos = [
               {
                 repo: 'tutor-contrib-aspects',
-                transifex_file_path: 'transifex_input.yaml'
+                transifex_file_path: 'transifex_input.yaml',
+              },
+              {
+                repo: 'openedx-app-ios',
+                transifex_file_path: 'I18N/I18N/en.lproj/Localizable.strings',
+                before_extract: 'make translation_requirements',
+                ref: 'develop',  // TODO: Use main branch https://github.com/openedx/openedx-translations/issues/6395
+              },
+              {
+                repo: 'openedx-app-android',
+                transifex_file_path: 'i18n/src/main/res/values/strings.xml',
+                before_extract: 'make translation_requirements',
+                ref: 'develop',  // TODO: Use main branch https://github.com/openedx/openedx-translations/issues/6395
               },
             ]
 
@@ -404,7 +416,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ${{ github.repository_owner }}/${{ matrix.repository_config.repo }}
-          ref: ${{ github.event.inputs.ref }}
+          ref: ${{ github.event.inputs.ref || matrix.repository_config.ref }}
           path: translations/${{ matrix.repository_config.repo }}
 
       # Sets up Python
@@ -416,6 +428,13 @@ jobs:
       # Installs Python requirements from translations.txt
       - name: install requirements
         run: pip install -r requirements/translations.txt
+
+      - name: run optional pre-extraction step
+        if: "${{ matrix.repository_config.before_extract }}"
+        run: |
+          # If the repository has additional requirements or processing steps run them
+          cd translations/${{ matrix.repository_config.repo }}
+          ${{ matrix.repository_config.before_extract }}
 
       # Extracts the translation source files
       - name: extract translation source files

--- a/transifex.yml
+++ b/transifex.yml
@@ -303,6 +303,22 @@ git:
     source_file_dir: translations/platform-plugin-aspects/platform_plugin_aspects/conf/locale/en/
     translation_files_expression: 'translations/platform-plugin-aspects/platform_plugin_aspects/conf/locale/<lang>/'
 
+  # openedx-app-android
+  - filter_type: file
+    file_format: ANDROID
+    source_file_extension: strings
+    source_language: en
+    source_file_dir: translations/openedx-app-android/i18n/src/main/res/values/strings.xml
+    translation_files_expression: 'translations/openedx-app-android/i18n/src/main/res/values-<lang>/strings.xml'
+
+  # openedx-app-ios
+  - filter_type: file
+    file_format: STRINGS
+    source_file_extension: strings
+    source_language: en
+    source_file_dir: translations/openedx-app-ios/I18N/I18N/en.lproj/Localizable.strings
+    translation_files_expression: 'translations/openedx-app-ios/I18N/I18N/<lang>.lproj/Localizable.strings'
+
   # RecommenderXBlock
   - filter_type: dir
     file_format: PO


### PR DESCRIPTION
### Changes
- Add https://github.com/openedx/openedx-app-ios to the list of supported repositories.
- Added support for optional translation requirements through `before_translate` step.

### TODO

- [x] Get the https://github.com/openedx/openedx-app-ios/pull/422 pull request merged
- [x] Get the https://github.com/openedx/openedx-app-android/pull/317 pull request merged
- [x] Test extract workflow on iOS: https://github.com/openedx/openedx-translations/commit/2691610eb67dca8afe84dbf8b1ff6c2c3ea403b3
- [x] Test extract workflow on Android: https://github.com/openedx/openedx-translations/commit/47e3bb89e3293ce8cb64960bbe7dccff0836bdcd

### Refs
This pull request is part of the [FC-0055 project](https://openedx.atlassian.net/l/cp/nSkaHb7G) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html) for mobile apps.
