### PR TITLE
chore: update Django to 3.2.25 for Redwood - Security Patch

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -26,7 +26,7 @@ click==8.1.7
     #   transifex-python
 coverage[toml]==7.3.2
     # via pytest-cov
-django==3.2.22
+django==3.2.25
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/translations.txt

--- a/requirements/translations.txt
+++ b/requirements/translations.txt
@@ -14,7 +14,7 @@ charset-normalizer==3.3.0
     # via requests
 click==8.1.7
     # via transifex-python
-django==3.2.22
+django==3.2.25
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   edx-i18n-tools


### PR DESCRIPTION
See: https://github.com/openedx/wg-build-test-release/issues/383