### PR TITLE
fix: Hand-fix a broken ar translation

### DIFF
--- a/translations/edx-platform/conf/locale/ar/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/ar/LC_MESSAGES/django.po
@@ -23602,7 +23602,7 @@ msgstr "اكتشف الجديد"
 
 #: lms/templates/header/navbar-logo-header.html:24
 msgid "{name} Dashboard"
-msgstr "{اسم} لوحة المعلومات"
+msgstr "{name} لوحة المعلومات"
 
 #: lms/templates/header/navbar-not-authenticated.html:24
 msgid "Supplemental Links"


### PR DESCRIPTION
This one was a high-profile string with a bad variable, causing errors on the site.