### PR TITLE
feat: bulk_update translation and reviews

### DIFF
--- a/scripts/fix_transifex_resource_names.py
+++ b/scripts/fix_transifex_resource_names.py
@@ -20,6 +20,8 @@ Slugs are even worse, sometimes they're also the lengthy while other times they'
  - "b8933764bdb3063ca09d6aa20341102f"
 
 This script updates slugs to be like names.
+
+Transifex Python API docs: https://github.com/transifex/transifex-python/blob/devel/transifex/api/README.md
 """
 
 import configparser

--- a/scripts/tests/test_release_project_sync.py
+++ b/scripts/tests/test_release_project_sync.py
@@ -172,12 +172,12 @@ def test_translations_entry_update_translation():
         translation='same translation',
     )
 
-    status = command.sync_translation_entry(
+    status, updates = command.determine_translation_updates(
         translation_from_old_project, current_translation
     )
 
-    assert status == 'updated'
-    assert current_translation.updates == {
+    assert status == 'update'
+    assert updates == {
         'reviewed': True,
     }
 
@@ -201,12 +201,12 @@ def test_translations_entry_more_recent_review():
         reviewed=True,
     )
 
-    status = command.sync_translation_entry(
+    status, updates = command.determine_translation_updates(
         translation_from_main_project, release_translation
     )
 
     assert status == 'no-op'
-    assert not release_translation.updates, 'save() should not be called'
+    assert not updates, 'updates should be empty'
 
 
 def test_translations_entry_dry_run():
@@ -226,12 +226,14 @@ def test_translations_entry_dry_run():
         translation='same translation',
     )
 
-    status = command.sync_translation_entry(
+    status, updates = command.determine_translation_updates(
         translation_from_old_project, current_translation
     )
 
-    assert status == 'updated-dry-run'
-    assert not current_translation.updates, 'save() should not be called in --dry-run mode'
+    assert status == 'update-dry-run'
+    assert updates == {
+        'reviewed': True,
+    }, 'Planned updates but never saved because of dry-run'
 
 
 def test_translations_entry_different_translation():
@@ -251,9 +253,9 @@ def test_translations_entry_different_translation():
         translation='another translation',
     )
 
-    status = command.sync_translation_entry(
+    status, updates = command.determine_translation_updates(
         translation_from_old_project, current_translation
     )
 
     assert status == 'no-op'
-    assert not current_translation.updates, 'save() should not be called in --dry-run mode'
+    assert updates == {}, ''


### PR DESCRIPTION
- Fixes for the sync translations workflow
- Use `bulk_update` for faster updates
- Sync translations if missing
- Sync tags
- Sync reviews (already there, but noting the feature for reviewers)


Example successful runs:

 - Arabic only (32 minutes): https://github.com/openedx/openedx-translations/actions/runs/12694941615
 - All languages for a single resource (7 minutes): https://github.com/openedx/openedx-translations/actions/runs/13202683973  
 - All languages for all resources (in progress): https://github.com/openedx/openedx-translations/actions/runs/13207292396