### PR TITLE
feat: use onlyreviewed for Redwood

### DIFF
--- a/transifex.yml
+++ b/transifex.yml
@@ -7,6 +7,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/AudioXBlock/audio/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/AudioXBlock/audio/conf/locale/<lang>/'
 
   # completion
@@ -15,6 +16,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/completion/completion/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/completion/completion/conf/locale/<lang>/'
 
   # course-discovery
@@ -23,6 +25,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/course-discovery/course_discovery/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/course-discovery/course_discovery/conf/locale/<lang>/'
 
   # credentials
@@ -31,6 +34,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/credentials/credentials/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/credentials/credentials/conf/locale/<lang>/'
 
   # credentials-themes
@@ -39,6 +43,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/credentials-themes/edx_credentials_themes/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/credentials-themes/edx_credentials_themes/conf/locale/<lang>/'
 
   # DoneXBlock
@@ -47,6 +52,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/DoneXBlock/done/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/DoneXBlock/done/conf/locale/<lang>/'
 
   # ecommerce
@@ -55,6 +61,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/ecommerce/ecommerce/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/ecommerce/ecommerce/conf/locale/<lang>/'
 
   # edx-ace
@@ -63,6 +70,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/edx-ace/edx_ace/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/edx-ace/edx_ace/conf/locale/<lang>/'
 
   # edx-bulk-grades
@@ -71,6 +79,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/edx-bulk-grades/bulk_grades/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/edx-bulk-grades/bulk_grades/conf/locale/<lang>/'
 
   # edx-enterprise
@@ -79,6 +88,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/edx-enterprise/enterprise/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/edx-enterprise/enterprise/conf/locale/<lang>/'
 
   # edx-ora2
@@ -87,6 +97,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/edx-ora2/openassessment/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/edx-ora2/openassessment/conf/locale/<lang>/'
 
   # edx-platform
@@ -95,6 +106,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/edx-platform/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/edx-platform/conf/locale/<lang>/'
 
   # edx-proctoring
@@ -103,6 +115,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/edx-proctoring/edx_proctoring/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/edx-proctoring/edx_proctoring/conf/locale/<lang>/'
 
   # FeedbackXBlock
@@ -111,6 +124,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/FeedbackXBlock/feedback/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/FeedbackXBlock/feedback/conf/locale/<lang>/'
 
   # frontend-app-account
@@ -118,6 +132,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-app-account/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-app-account/src/i18n/messages/<lang>.json'
 
   # frontend-app-admin-portal
@@ -125,6 +140,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-app-admin-portal/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-app-admin-portal/src/i18n/messages/<lang>.json'
 
   # frontend-app-authn
@@ -132,6 +148,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-app-authn/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-app-authn/src/i18n/messages/<lang>.json'
 
   # frontend-app-communications
@@ -139,6 +156,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-app-communications/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-app-communications/src/i18n/messages/<lang>.json'
 
   # frontend-app-course-authoring
@@ -146,6 +164,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-app-course-authoring/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-app-course-authoring/src/i18n/messages/<lang>.json'
 
   # frontend-app-discussions
@@ -153,6 +172,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-app-discussions/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-app-discussions/src/i18n/messages/<lang>.json'
 
   # frontend-app-ecommerce
@@ -160,6 +180,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-app-ecommerce/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-app-ecommerce/src/i18n/messages/<lang>.json'
 
   # frontend-app-enterprise-public-catalog
@@ -167,6 +188,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-app-enterprise-public-catalog/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-app-enterprise-public-catalog/src/i18n/messages/<lang>.json'
 
   # frontend-app-gradebook
@@ -174,6 +196,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-app-gradebook/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-app-gradebook/src/i18n/messages/<lang>.json'
 
   # frontend-app-learner-dashboard
@@ -181,6 +204,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-app-learner-dashboard/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-app-learner-dashboard/src/i18n/messages/<lang>.json'
 
   # frontend-app-learner-record
@@ -188,6 +212,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-app-learner-record/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-app-learner-record/src/i18n/messages/<lang>.json'
 
   # frontend-app-learning
@@ -195,6 +220,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-app-learning/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-app-learning/src/i18n/messages/<lang>.json'
 
   # frontend-app-library-authoring
@@ -202,6 +228,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-app-library-authoring/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-app-library-authoring/src/i18n/messages/<lang>.json'
 
   # frontend-app-ora-grading
@@ -209,6 +236,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-app-ora-grading/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-app-ora-grading/src/i18n/messages/<lang>.json'
 
   # frontend-app-payment
@@ -216,6 +244,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-app-payment/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-app-payment/src/i18n/messages/<lang>.json'
 
   # frontend-app-profile
@@ -223,6 +252,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-app-profile/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-app-profile/src/i18n/messages/<lang>.json'
 
   # frontend-app-program-console
@@ -230,6 +260,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-app-program-console/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-app-program-console/src/i18n/messages/<lang>.json'
 
   # frontend-app-support-tools
@@ -237,6 +268,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-app-support-tools/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-app-support-tools/src/i18n/messages/<lang>.json'
 
   # frontend-component-footer
@@ -244,6 +276,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-component-footer/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-component-footer/src/i18n/messages/<lang>.json'
 
   # frontend-component-header
@@ -251,6 +284,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-component-header/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-component-header/src/i18n/messages/<lang>.json'
 
   # frontend-lib-content-components
@@ -258,6 +292,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-lib-content-components/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-lib-content-components/src/i18n/messages/<lang>.json'
 
   # frontend-lib-special-exams
@@ -265,6 +300,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-lib-special-exams/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-lib-special-exams/src/i18n/messages/<lang>.json'
 
   # frontend-platform
@@ -272,6 +308,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-platform/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-platform/src/i18n/messages/<lang>.json'
 
   # frontend-app-learner-portal-enterprise
@@ -279,6 +316,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/frontend-app-learner-portal-enterprise/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/frontend-app-learner-portal-enterprise/src/i18n/messages/<lang>.json'
 
   # paragon
@@ -286,6 +324,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/paragon/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/paragon/src/i18n/messages/<lang>.json'
 
   # platform-plugin-aspects
@@ -294,6 +333,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/platform-plugin-aspects/platform_plugin_aspects/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/platform-plugin-aspects/platform_plugin_aspects/conf/locale/<lang>/'
 
   # RecommenderXBlock
@@ -302,6 +342,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/RecommenderXBlock/recommender/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/RecommenderXBlock/recommender/conf/locale/<lang>/'
 
   # studio-frontend
@@ -309,6 +350,7 @@ git:
     file_format: KEYVALUEJSON
     source_language: en
     source_file: translations/studio-frontend/src/i18n/transifex_input.json
+    mode: onlyreviewed
     translation_files_expression: 'translations/studio-frontend/src/i18n/messages/<lang>.json'
 
   # tutor-contrib-aspects
@@ -316,6 +358,7 @@ git:
     file_format: YAML_GENERIC
     source_language: en
     source_file: translations/tutor-contrib-aspects/transifex_input.yaml
+    mode: onlyreviewed
     translation_files_expression: 'translations/tutor-contrib-aspects/tutoraspects/templates/aspects/apps/superset/conf/locale/<lang>/locale.yaml'
 
   # xblock-drag-and-drop-v2
@@ -324,6 +367,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/xblock-drag-and-drop-v2/drag_and_drop_v2/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/xblock-drag-and-drop-v2/drag_and_drop_v2/conf/locale/<lang>/'
 
   # xblock-free-text-response
@@ -332,6 +376,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/xblock-free-text-response/freetextresponse/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/xblock-free-text-response/freetextresponse/conf/locale/<lang>/'
 
   # xblock-google-drive
@@ -340,6 +385,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/xblock-google-drive/google_drive/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/xblock-google-drive/google_drive/conf/locale/<lang>/'
 
   # xblock-image-explorer
@@ -348,6 +394,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/xblock-image-explorer/image_explorer/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/xblock-image-explorer/image_explorer/conf/locale/<lang>/'
 
   # xblock-image-modal
@@ -356,6 +403,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/xblock-image-modal/imagemodal/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/xblock-image-modal/imagemodal/conf/locale/<lang>/'
 
   # xblock-lti-consumer
@@ -364,6 +412,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/xblock-lti-consumer/lti_consumer/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/xblock-lti-consumer/lti_consumer/conf/locale/<lang>/'
 
   # xblock-qualtrics-survey
@@ -372,6 +421,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/xblock-qualtrics-survey/qualtricssurvey/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/xblock-qualtrics-survey/qualtricssurvey/conf/locale/<lang>/'
 
   # xblock-sql-grader
@@ -380,6 +430,7 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/xblock-sql-grader/sql_grader/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/xblock-sql-grader/sql_grader/conf/locale/<lang>/'
 
   # xblock-submit-and-compare
@@ -388,4 +439,5 @@ git:
     source_file_extension: po
     source_language: en
     source_file_dir: translations/xblock-lti-consumer/lti_consumer/conf/locale/en/
+    mode: onlyreviewed
     translation_files_expression: 'translations/xblock-lti-consumer/lti_consumer/conf/locale/<lang>/'


### PR DESCRIPTION
This pull request uses the new `mode: onlyreviewed` feature recently released by Transifex:

 - https://community.transifex.com/t/configure-translation-file-modes-for-git-repo-integrations/4465
 - https://community.transifex.com/t/github-integration-sync-only-reviewed-strings/3831/14

The documentation has no clear mention of `onlyreviewed` therefore we need to merge this pull request before it can be tested.

- Related issue: https://github.com/openedx/wg-translations/issues/43

### Other related changes

 - Transifex GitHub Integration settings will be changed from `Reviewed: 100%` to `Reviewed: 30%` to make it more usable for translators. We can play with the numbers as we wish later.