### PR TITLE
fix: add missing space in the additional.help.text field

### DIFF
--- a/translations/frontend-app-authn/src/i18n/messages/ar.json
+++ b/translations/frontend-app-authn/src/i18n/messages/ar.json
@@ -39,7 +39,7 @@
   "confirmation.message.title": "تفقّد بريدك الإلكتروني",
   "confirmation.support.link": "اتصل بالدعم الفني",
   "need.help.sign.in.text": "هل تحتاج مساعدة في تسجيل الدخول؟",
-  "additional.help.text": "للحصول على مساعدة إضافية، اتصل بدعم {platformName} على",
+  "additional.help.text": "للحصول على مساعدة إضافية، اتصل بدعم {platformName} على ",
   "sign.in.text": "تسجيل الدخول",
   "extend.field.errors": "{emailError} أدناه.",
   "invalid.token.heading": "رابط إعادة ضبط كلمة المرور غير صالح",

--- a/translations/frontend-app-authn/src/i18n/messages/da.json
+++ b/translations/frontend-app-authn/src/i18n/messages/da.json
@@ -39,7 +39,7 @@
   "confirmation.message.title": "Tjek din Email",
   "confirmation.support.link": "kontakt teknisk support",
   "need.help.sign.in.text": "Har du brug for hjælp til at logge ind?",
-  "additional.help.text": "For yderligere hjælp, kontakt {platformName} support på",
+  "additional.help.text": "For yderligere hjælp, kontakt {platformName} support på ",
   "sign.in.text": "",
   "extend.field.errors": "{emailError} nedenfor.",
   "invalid.token.heading": "Link til nulstilling af ugyldig password",

--- a/translations/frontend-app-authn/src/i18n/messages/es_419.json
+++ b/translations/frontend-app-authn/src/i18n/messages/es_419.json
@@ -39,7 +39,7 @@
   "confirmation.message.title": "Verifica tu correo electrónico",
   "confirmation.support.link": "entra en contacto con el equipo de soporte técnico",
   "need.help.sign.in.text": "¿Necesitas ayuda para iniciar sesión?",
-  "additional.help.text": "Para obtener ayuda adicional, comuníquese con el soporte {platformName} en",
+  "additional.help.text": "Para obtener ayuda adicional, comuníquese con el soporte {platformName} en ",
   "sign.in.text": "Iniciar sesión",
   "extend.field.errors": "{emailError} a continuación.",
   "invalid.token.heading": "Enlace de restablecimiento de contraseña inválido",

--- a/translations/frontend-app-authn/src/i18n/messages/es_ES.json
+++ b/translations/frontend-app-authn/src/i18n/messages/es_ES.json
@@ -39,7 +39,7 @@
   "confirmation.message.title": "Verifica tu correo electrónico",
   "confirmation.support.link": "contacta con el equipo de soporte técnico",
   "need.help.sign.in.text": "¿Necesitas ayuda para iniciar sesión?",
-  "additional.help.text": "Para obtener ayuda adicional, comuníquese con el soporte de {platformName} en",
+  "additional.help.text": "Para obtener ayuda adicional, comuníquese con el soporte de {platformName} en ",
   "sign.in.text": "Iniciar sesión",
   "extend.field.errors": "{emailError} a continuación.",
   "invalid.token.heading": "Enlace de restablecimiento de contraseña no válido",

--- a/translations/frontend-app-authn/src/i18n/messages/fa.json
+++ b/translations/frontend-app-authn/src/i18n/messages/fa.json
@@ -39,7 +39,7 @@
   "confirmation.message.title": "ایمیل خود را چک کنید",
   "confirmation.support.link": "با پشتیبانی فنی تماس بگیرید",
   "need.help.sign.in.text": "برای ورود به سیستم به کمک نیاز دارید؟",
-  "additional.help.text": "برای راهنمایی بیش‌تر، با پشتیبانی {platformName} تماس بگیرید",
+  "additional.help.text": "برای راهنمایی بیش‌تر، با پشتیبانی {platformName} تماس بگیرید ",
   "sign.in.text": "ورود",
   "extend.field.errors": "{emailError} زیر.",
   "invalid.token.heading": "لینک بازنشانی رمز عبور نامعتبر است",

--- a/translations/frontend-app-authn/src/i18n/messages/fr_CA.json
+++ b/translations/frontend-app-authn/src/i18n/messages/fr_CA.json
@@ -39,7 +39,7 @@
   "confirmation.message.title": "Vérifiez votre courriel",
   "confirmation.support.link": "contacter le support technique",
   "need.help.sign.in.text": "Besoin d'aide pour vous connecter?",
-  "additional.help.text": "Pour obtenir de l'aide supplémentaire, contactez l'assistance {platformName} à l'adresse",
+  "additional.help.text": "Pour obtenir de l'aide supplémentaire, contactez l'assistance {platformName} à l'adresse ",
   "sign.in.text": "Connexion",
   "extend.field.errors": "{emailError} ci-dessous.",
   "invalid.token.heading": "Lien de réinitialisation du mot de passe non valide",

--- a/translations/frontend-app-authn/src/i18n/messages/he.json
+++ b/translations/frontend-app-authn/src/i18n/messages/he.json
@@ -39,7 +39,7 @@
   "confirmation.message.title": "נא לבדוק את המייל ",
   "confirmation.support.link": "פנה לתמיכה הטכנית",
   "need.help.sign.in.text": "אפשר להציע עזרה בכניסה לאתר?",
-  "additional.help.text": "לעזרה נוספת, פנה לתמיכה של {platformName} בכתובת",
+  "additional.help.text": "לעזרה נוספת, פנה לתמיכה של {platformName} בכתובת ",
   "sign.in.text": "כניסה",
   "extend.field.errors": "{emailError} למטה.",
   "invalid.token.heading": "קישור לאיפוס סיסמה לא חוקי",

--- a/translations/frontend-app-authn/src/i18n/messages/hi.json
+++ b/translations/frontend-app-authn/src/i18n/messages/hi.json
@@ -39,7 +39,7 @@
   "confirmation.message.title": "अपना ईमेल देखें",
   "confirmation.support.link": "तकनीकी सहायता से संपर्क करें",
   "need.help.sign.in.text": "साइन इन करने में मदद चाहिए?",
-  "additional.help.text": "अतिरिक्त सहायता के लिए, {platformName} सहायता से संपर्क करें",
+  "additional.help.text": "अतिरिक्त सहायता के लिए, {platformName} सहायता से संपर्क करें ",
   "sign.in.text": "साइन इन करें",
   "extend.field.errors": "नीचे {emailError}।",
   "invalid.token.heading": "अमान्य पासवर्ड रीसेट लिंक",

--- a/translations/frontend-app-authn/src/i18n/messages/id.json
+++ b/translations/frontend-app-authn/src/i18n/messages/id.json
@@ -39,7 +39,7 @@
   "confirmation.message.title": "Check your email",
   "confirmation.support.link": "contact technical support",
   "need.help.sign.in.text": "Need help signing in?",
-  "additional.help.text": "For additional help, contact {platformName} support at",
+  "additional.help.text": "For additional help, contact {platformName} support at ",
   "sign.in.text": "Sign in",
   "extend.field.errors": "{emailError} below.",
   "invalid.token.heading": "Invalid password reset link",

--- a/translations/frontend-app-authn/src/i18n/messages/lv.json
+++ b/translations/frontend-app-authn/src/i18n/messages/lv.json
@@ -39,7 +39,7 @@
   "confirmation.message.title": "Pārbaudiet savu e-pastu",
   "confirmation.support.link": "sazinieties ar tehnisko atbalstu",
   "need.help.sign.in.text": "Vai nepieciešama palīdzība pierakstoties?",
-  "additional.help.text": "Lai saņemtu papildu palīdzību, sazinieties ar {platformName} atbalsta dienestu vietnē",
+  "additional.help.text": "Lai saņemtu papildu palīdzību, sazinieties ar {platformName} atbalsta dienestu vietnē ",
   "sign.in.text": "Ielogoties",
   "extend.field.errors": "{emailError} zemāk.",
   "invalid.token.heading": "Nederīga paroles atiestatīšanas saite",

--- a/translations/frontend-app-authn/src/i18n/messages/pt_BR.json
+++ b/translations/frontend-app-authn/src/i18n/messages/pt_BR.json
@@ -39,7 +39,7 @@
   "confirmation.message.title": "Verifique o seu e-mail",
   "confirmation.support.link": "entre em contato com o suporte técnico",
   "need.help.sign.in.text": "Precisa de ajuda para fazer login?",
-  "additional.help.text": "Para obter ajuda adicional, entre em contato com o suporte {platformName} em",
+  "additional.help.text": "Para obter ajuda adicional, entre em contato com o suporte {platformName} em ",
   "sign.in.text": "Entrar",
   "extend.field.errors": "{emailError} abaixo.",
   "invalid.token.heading": "Link de redefinição de senha inválido",

--- a/translations/frontend-app-authn/src/i18n/messages/pt_PT.json
+++ b/translations/frontend-app-authn/src/i18n/messages/pt_PT.json
@@ -39,7 +39,7 @@
   "confirmation.message.title": "Verifique o seu email",
   "confirmation.support.link": "contacto o suporte técnico",
   "need.help.sign.in.text": "Precisa de ajuda para entrar?",
-  "additional.help.text": "Para ajuda adicional, contacte o suporte de {platformName} em",
+  "additional.help.text": "Para ajuda adicional, contacte o suporte de {platformName} em ",
   "sign.in.text": "Iniciar sessão",
   "extend.field.errors": "{emailError} abaixo.",
   "invalid.token.heading": "Link para Redefinir Palavra-passe inválido",

--- a/translations/frontend-app-authn/src/i18n/messages/ru.json
+++ b/translations/frontend-app-authn/src/i18n/messages/ru.json
@@ -39,7 +39,7 @@
   "confirmation.message.title": "Проверьте свою электронную почту",
   "confirmation.support.link": "связаться с техподдержкой",
   "need.help.sign.in.text": "Нужна помощь со входом?",
-  "additional.help.text": "Для получения дополнительной помощи обратитесь в службу поддержки {platformName} по адресу",
+  "additional.help.text": "Для получения дополнительной помощи обратитесь в службу поддержки {platformName} по адресу ",
   "sign.in.text": "Вход",
   "extend.field.errors": "{emailError} ниже.",
   "invalid.token.heading": "Неверная ссылка для сброса пароля",

--- a/translations/frontend-app-authn/src/i18n/messages/sw.json
+++ b/translations/frontend-app-authn/src/i18n/messages/sw.json
@@ -39,7 +39,7 @@
   "confirmation.message.title": "Angalia barua pepe yako",
   "confirmation.support.link": "wasiliana na usaidizi wa kiufundi",
   "need.help.sign.in.text": "Je, unahitaji usaidizi wa kuingia?",
-  "additional.help.text": "Kwa usaidizi zaidi, wasiliana na usaidizi wa {platformName} kwa",
+  "additional.help.text": "Kwa usaidizi zaidi, wasiliana na usaidizi wa {platformName} kwa ",
   "sign.in.text": "Weka sahihi",
   "extend.field.errors": "{emailError} hapa chini.",
   "invalid.token.heading": "Kiungo batili cha kuweka upya nenosiri",

--- a/translations/frontend-app-authn/src/i18n/messages/te.json
+++ b/translations/frontend-app-authn/src/i18n/messages/te.json
@@ -39,7 +39,7 @@
   "confirmation.message.title": "మీ ఈమెయిలు చూసుకోండి",
   "confirmation.support.link": "సాంకేతిక మద్దతును సంప్రదించండి",
   "need.help.sign.in.text": "సైన్ ఇన్ చేయడంలో సహాయం కావాలా?",
-  "additional.help.text": "అదనపు సహాయం కోసం, వద్ద {platformName} మద్దతును సంప్రదించండి",
+  "additional.help.text": "అదనపు సహాయం కోసం, వద్ద {platformName} మద్దతును సంప్రదించండి ",
   "sign.in.text": "సైన్ ఇన్ చేయండి",
   "extend.field.errors": "{emailError} క్రింద.",
   "invalid.token.heading": "చెల్లని పాస్‌వర్డ్ రీసెట్ లింక్",

--- a/translations/frontend-app-authn/src/i18n/messages/th.json
+++ b/translations/frontend-app-authn/src/i18n/messages/th.json
@@ -39,7 +39,7 @@
   "confirmation.message.title": "ตรวจสอบอีเมล",
   "confirmation.support.link": "ติดต่อเจ้าหน้าที่ทางเทคนิค",
   "need.help.sign.in.text": "ต้องการความช่วยเหลือในการเข้าสู่ระบบไหม?",
-  "additional.help.text": "หากต้องการความช่วยเหลือเพิ่มเติม โปรดติดต่อฝ่ายสนับสนุน {platformName} ที่",
+  "additional.help.text": "หากต้องการความช่วยเหลือเพิ่มเติม โปรดติดต่อฝ่ายสนับสนุน {platformName} ที่ ",
   "sign.in.text": "เข้าสู่ระบบ",
   "extend.field.errors": "{emailError} ด้านล่าง",
   "invalid.token.heading": "ลิงก์การรีเซ็ทรหัสผ่านไม่ถูกต้อง",

--- a/translations/frontend-app-authn/src/i18n/messages/tr_TR.json
+++ b/translations/frontend-app-authn/src/i18n/messages/tr_TR.json
@@ -39,7 +39,7 @@
   "confirmation.message.title": "E-postanızı kontrol ediniz",
   "confirmation.support.link": "teknik destek ile iletişime geçin",
   "need.help.sign.in.text": "Giriş yapmak için yardıma mı ihtiyacınız var?",
-  "additional.help.text": "Ek yardım için şu adresten {platformName} desteğine başvurun:",
+  "additional.help.text": "Ek yardım için şu adresten {platformName} desteğine başvurun: ",
   "sign.in.text": "Giriş Yap",
   "extend.field.errors": "{emailError} aşağıda.",
   "invalid.token.heading": "Geçersiz parola sıfırlama bağlantısı",

--- a/translations/frontend-app-authn/src/i18n/messages/uk.json
+++ b/translations/frontend-app-authn/src/i18n/messages/uk.json
@@ -39,7 +39,7 @@
   "confirmation.message.title": "Перевірте свою пошту",
   "confirmation.support.link": "звернутися до служби підтримки",
   "need.help.sign.in.text": "Потрібна допомога для входу?",
-  "additional.help.text": "Щоб отримати додаткову допомогу, зверніться до служби підтримки {platformName} за адресою",
+  "additional.help.text": "Щоб отримати додаткову допомогу, зверніться до служби підтримки {platformName} за адресою ",
   "sign.in.text": "Увійти",
   "extend.field.errors": "{emailError}, що вказана нижче.",
   "invalid.token.heading": "Недійсне посилання на скидання паролю",

--- a/translations/frontend-app-authn/src/i18n/messages/uz.json
+++ b/translations/frontend-app-authn/src/i18n/messages/uz.json
@@ -39,7 +39,7 @@
   "confirmation.message.title": "Elektron pochtangizni tekshiring",
   "confirmation.support.link": "texnik yordamga murojaat qiling",
   "need.help.sign.in.text": "Accountga kirishda yordam kerakmi?",
-  "additional.help.text": "Qo'shimcha yordam uchun {platformName} qo'llab-quvvatlash xizmatiga murojaat qiling",
+  "additional.help.text": "Qo'shimcha yordam uchun {platformName} qo'llab-quvvatlash xizmatiga murojaat qiling ",
   "sign.in.text": "Tizimga kirish",
   "extend.field.errors": "{emailError} quyida.",
   "invalid.token.heading": "Parolni tiklash havolasi noto‘g‘ri",

--- a/translations/frontend-app-authn/src/i18n/messages/vi.json
+++ b/translations/frontend-app-authn/src/i18n/messages/vi.json
@@ -39,7 +39,7 @@
   "confirmation.message.title": "Kiểm tra hộp thư điện tử của bạn",
   "confirmation.support.link": "liên hệ hỗ trợ kỹ thuật",
   "need.help.sign.in.text": "Cần trợ giúp đăng nhập?",
-  "additional.help.text": "Để được trợ giúp thêm, hãy liên hệ với bộ phận hỗ trợ {platformName} tại",
+  "additional.help.text": "Để được trợ giúp thêm, hãy liên hệ với bộ phận hỗ trợ {platformName} tại ",
   "sign.in.text": "Đăng nhập",
   "extend.field.errors": "{emailError} bên dưới.",
   "invalid.token.heading": "Liên kết đặt lại mật khẩu không hợp lệ",

--- a/translations/frontend-app-authn/src/i18n/transifex_input.json
+++ b/translations/frontend-app-authn/src/i18n/transifex_input.json
@@ -39,7 +39,7 @@
   "confirmation.message.title": "Check your email",
   "confirmation.support.link": "contact technical support",
   "need.help.sign.in.text": "Need help signing in?",
-  "additional.help.text": "For additional help, contact {platformName} support at",
+  "additional.help.text": "For additional help, contact {platformName} support at ",
   "sign.in.text": "Sign in",
   "extend.field.errors": "{emailError} below.",
   "invalid.token.heading": "Invalid password reset link",


### PR DESCRIPTION
There is a issue, that almost in all translations there is no space between `"additional.help.text"` field and `{getConfig().INFO_EMAIL}` in the frontend-app-authn

<img width="1459" alt="wqa122a" src="https://github.com/user-attachments/assets/a253fea7-8586-4571-aef6-b4c2e7a324ca" />

For example in the files `translations/frontend-app-authn/src/i18n/messages/de.json` or `translations/frontend-app-authn/src/i18n/messages/zh_HK.json` spaces are present

<img width="1071" alt="Screenshot 2025-07-10 at 11 57 13" src="https://github.com/user-attachments/assets/4d5f7a84-63a2-47d1-adb6-09dc3b3f9d30" />
<img width="962" alt="Screenshot 2025-07-10 at 11 57 03" src="https://github.com/user-attachments/assets/708fad31-024e-4471-886f-2f6ab200a4b9" />

