### PR TITLE
feat: unique resource slugs

### DIFF
--- a/.github/workflows/fix-transifex-resource-names.yml
+++ b/.github/workflows/fix-transifex-resource-names.yml
@@ -3,7 +3,6 @@
 name: Fix Transifex resource names and slugs
 
 on:
-  workflow_dispatch:  # by request
   push:  # after adding repositories to the openedx-translations repo
     branches: [ main ]
     paths:
@@ -11,6 +10,23 @@ on:
       - '.github/workflows/extract-translation-source-files.yml'
   schedule:  # Also run monthly just in case there's a stall slug/name update
     - cron: '0 0 1 * *'
+  workflow_dispatch:  # by request
+    inputs:
+      release_name:
+        description: 'Release name e.g. redwood, sumac, , etc or main for the latest project (defaults to "main").'
+        required: true
+        default: main
+        type: string
+      dry_run:
+        description: 'If true, will not make any changes to Transifex'
+        required: false
+        default: true
+        type: boolean
+      force_suffix:
+        description: 'If true, will force suffix to be added to the resource Transifex slug'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   resource-names:
@@ -31,6 +47,20 @@ jobs:
       - name: Fix transifex automatic resource names
         env:
           TRANSIFEX_API_TOKEN: ${{ secrets.TRANSIFEX_API_TOKEN }}
+          RELEASE: ${{ inputs.release_name }}
         run: |
           make translations_scripts_requirements
-          make fix_transifex_resource_names
+
+          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+            if [[ "${{ inputs.force_suffix }}" == "true" ]]; then
+              make fix_force_suffix_dry_run_transifex_resource_names;
+            else
+              make fix_dry_run_transifex_resource_names;
+            fi
+          else
+            if [[ "${{ inputs.force_suffix }}" == "true" ]]; then
+              make fix_force_suffix_transifex_resource_names;
+            else
+              make fix_transifex_resource_names;
+            fi
+          fi

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 validate_translation_files test_requirements test fix_transifex_resource_names_dry_run \
 retry_merge_transifex_bot_pull_requests
 
-# Default project to work on. Override to release project e.g. `openedx-translations-redwood` when cutting a release.
-export TRANSIFEX_PROJECT_SLUG := openedx-translations
+# Default release/project to work on. Override to release project e.g. `zebrawood` when cutting a release.
+export RELEASE := main
 
 piptools:
 	pip install -q -r requirements/pip_tools.txt
@@ -21,12 +21,17 @@ upgrade: piptools  ## update the requirements/*.txt files with the latest packag
 translations_scripts_requirements:  ## Installs the requirements file
 	pip install -q -r requirements/translations.txt
 
-fix_transifex_resource_names:  ## Runs the script on the TRANSIFEX_PROJECT_SLUG project
-	python scripts/fix_transifex_resource_names.py
+fix_transifex_resource_names:  ## Runs the script on the RELEASE project
+	python scripts/fix_transifex_resource_names.py --release=$(RELEASE)
 
-fix_transifex_resource_names_dry_run:  ## Runs the script in --dry-run mode on the TRANSIFEX_PROJECT_SLUG project
-	python scripts/fix_transifex_resource_names.py --dry-run
+fix_dry_run_transifex_resource_names:  ## Runs the script in --dry-run mode on the RELEASE project
+	python scripts/fix_transifex_resource_names.py --dry-run --release=$(RELEASE)
 
+fix_force_suffix_transifex_resource_names:  ## Runs the script on the RELEASE project with --force-suffix
+	python scripts/fix_transifex_resource_names.py --force-suffix --release=$(RELEASE)
+
+fix_force_suffix_dry_run_transifex_resource_names:  ## Runs the script in --dry-run mode on the RELEASE project with --force-suffix
+	python scripts/fix_transifex_resource_names.py --force-suffix --dry-run --release=$(RELEASE)
 
 test_requirements:  ## Installs test.txt requirements
 	pip install -q -r requirements/test.txt

--- a/scripts/fix_transifex_resource_names.py
+++ b/scripts/fix_transifex_resource_names.py
@@ -1,8 +1,7 @@
 """
-Set the openedx-translations to readable resource names and slugs:
+Set the Transifex projects resources to have readable resource names and slugs:
 
 Run via `$ make fix_transifex_resource_names`.
-
 
 Transifex sets resource slug names and slugs to a long name which makes it unreadable by translators .e.g.
  - "translations..frontend-app-something..src-i18n-transifex-input--main"
@@ -16,48 +15,79 @@ This script infer the resource name in two ways:
  - ["github#repository:openedx/openedx-translations#branch:main#path:translations/my-xblock/openassessment/conf/locale/en/LC_MESSAGES/djangojs.po"]
    would result in "my-xblock-js" as resource name.
 
-Slugs are even worse, sometimes they're also the lengthy while other times they're just hashes e.g.
+
+Slugs are even worse than random names, sometimes they're also the lengthy while other times they're just hashes e.g.
  - "b8933764bdb3063ca09d6aa20341102f"
 
-This script updates slugs to be like names.
+Slug deduplication: Slugs are used by internal Transifex applications, so this script adds a random suffix to avoid
+                    slug collisions across projects.
 
 Transifex Python API docs: https://github.com/transifex/transifex-python/blob/devel/transifex/api/README.md
 """
 
+import argparse
 import configparser
 import re
 import sys
+import random
+import string
 from os import getenv
 from os.path import expanduser
 
 from slugify import slugify
 from transifex.api import transifex_api
 
+# Use random suffix to avoid slug collisions across projects
+# See the AI Transifex translations postmortem for more details:
+#   - https://github.com/openedx/openedx-translations/issues/41695
+UNIQUE_RESOURCE_SLUG_REGEXP = re.compile(r'^[a-z0-9-]*-r[0-9]{4}$')
 
-def is_dry_run():
-    """
-    Check if the script is running in debug mode.
-    """
-    return '--dry-run' in sys.argv
+# Slugs are just hashes (e.g. "b8933764bdb3063ca09d6aa20341102f") should be made readable
+RESOURCE_SLUG_IS_JUST_HASH_REGEXP = re.compile(r'^[a-z0-9]{32}$')
 
 
-def get_transifex_project_slug():
+def parse_arguments():
     """
-    Get Transifex project slug e.g. openedx-translations or openedx-translations-<release-name>.
+    Parse command line arguments.
     """
-    slug = getenv('TRANSIFEX_PROJECT_SLUG')
-    if not slug:
-        raise RuntimeError(
-            'Error: Cannot determine Transifex project slug. Set `TRANSIFEX_PROJECT_SLUG` environment variable to '
-            '"openedx-translations" or "openedx-translations-<release-name>". '
+    parser = argparse.ArgumentParser(
+        description=f'Update Transifex resource names and slugs to be more readable. \n {__doc__}',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Run in dry-run mode without making any changes'
+    )
+    parser.add_argument(
+        '--force-suffix',
+        action='store_true',
+        help='Force suffix to be added to the resource Transifex slug'
+    )
+    parser.add_argument(
+        '--release',
+        dest='release',
+        required=True,
+        help=(
+            'Release name e.g. "main", "redwood", "quince", "palm", etc. '
             'List of Open edX releases are available in the following page: '
             'https://openedx.atlassian.net/wiki/spaces/OEPM/pages/4191191044/Open+edX+Releases+Homepage'
-        )
+        ),
+    )
+    return parser.parse_args()
 
-    return slug
+
+def get_project_slug_from_release(release):
+    """
+    Convert release name to Transifex project slug.
+    """
+    if release == 'main':
+        return 'openedx-translations'
+    else:
+        return f'openedx-translations-{release}'
 
 
-def get_transifex_project():
+def get_transifex_project(release):
     """
     Get the translations project object from Transifex.
     """
@@ -76,10 +106,18 @@ def get_transifex_project():
     transifex_api.setup(auth=transifex_api_token)
 
     openedx_org = transifex_api.Organization.get(slug='open-edx')
-    return openedx_org.fetch('projects').get(slug=get_transifex_project_slug())
+    project_slug = get_project_slug_from_release(release)
+    return openedx_org.fetch('projects').get(slug=project_slug)
 
 
-def get_repo_slug_from_resource(resource):
+def generate_short_random_suffix(length=4):
+    return ''.join(random.choice(string.digits) for i in range(length))
+
+
+def get_repo_name_from_resource(resource):
+    """
+    Get a human-readable resource name from the resource categories and file path.
+    """
     if resource.categories:
         github_repo_categories = [
             category for category in resource.categories if 'github#repository' in category
@@ -113,15 +151,49 @@ def get_repo_slug_from_resource(resource):
                     return new_name
 
 
-def main(argv):
-    if '--help' in argv:
-        # Print help document.
-        print(__doc__)
-        return
+def get_repo_slug_from_resource(resource, release):
+    """
+    Get a unique human-readable resource slug from the resource name and categories.
+    """
+    # If the current slug already has a unique suffix, keep it
+    if UNIQUE_RESOURCE_SLUG_REGEXP.match(resource.slug):
+        return resource.slug
 
-    print(f'Updating "{get_transifex_project_slug()}" project resource and slug names:')
+    clean_non_unique_current_name = None
+    if resource.slug == resource.name.lower():
+        # Resource has a clean name, but not unique
+        clean_non_unique_current_name = resource.slug
 
-    openedx_translations_proj = get_transifex_project()
+    new_name = get_repo_name_from_resource(resource)
+    if new_name:
+        if UNIQUE_RESOURCE_SLUG_REGEXP.match(new_name):
+            return new_name
+        else:
+            return f'{new_name}-{release}-r{generate_short_random_suffix()}'
+    elif clean_non_unique_current_name:
+        return f'{clean_non_unique_current_name}-{release}-r{generate_short_random_suffix()}'
+
+
+def main():
+    args = parse_arguments()
+
+    try:
+        release = args.release
+        project_slug = get_project_slug_from_release(release)
+        print(f'Updating "{project_slug}" project resource and slug names:')
+        if args.dry_run:
+            print('Running in dry-run mode. No changes will be made.')
+    except Exception as e:
+        print(f'Error: {e}', file=sys.stderr)
+        return 1
+
+    openedx_translations_proj = get_transifex_project(release)
+
+    # Track changes for summary
+    name_changes = 0
+    slug_changes = 0
+    skipped_resources = 0
+
     for resource in openedx_translations_proj.fetch('resources'):
         print('------------')
         print('Updating:')
@@ -130,38 +202,60 @@ def main(argv):
         print('Resource name:', resource.name)
         print('Resource categories:', ', '.join(resource.categories))
 
-        new_name = get_repo_slug_from_resource(resource)
-        new_slug = get_repo_slug_from_resource(resource)
+        new_name = get_repo_name_from_resource(resource)
+        new_slug = get_repo_slug_from_resource(resource, release)
 
         if resource.name.startswith('translations..'):
             if new_name and resource.name != new_name:
                 resource.name = new_name
-                if is_dry_run():
-                    print(f'\n### Saving new name "{new_name}" (dry-run) ###', '\n')
+                name_changes += 1
+                if args.dry_run:
+                    print(f'\n### Would save new name "{new_name}" (dry-run) ###', '\n')
                 else:
                     print(f'\n### Saving new name "{new_name}" ###', '\n')
                     resource.save('name')
             else:
                 print(f'Error: Unrecognized slug pattern or categories to infer resource resource name from.')
 
-        if re.match('^[a-z0-9]{32}$', resource.slug) or resource.slug.startswith('translations-'):
-            if new_slug and resource.slug != new_slug:
-                resource.slug = new_slug
-                if is_dry_run():
-                    print(f'\n### Saving new slug "{new_slug}" (dry-run) ###', '\n')
-                else:
-                    print(f'\n### Saving new slug "{new_slug}" ###', '\n')
-                    try:
-                        resource.save('slug')
-                    except Exception as e:
-                        # Slug is unique, so if it already exists, we get an error.
-                        print(f'Error: {e}')
+        force_slug = not UNIQUE_RESOURCE_SLUG_REGEXP.match(resource.slug) and args.force_suffix
+        if (
+            RESOURCE_SLUG_IS_JUST_HASH_REGEXP.match(resource.slug)
+            or resource.slug.startswith('translations-')
+            or force_slug
+        ):
+            if new_slug:
+                force_slug_note = ' (force suffix)' if force_slug else ''
+                if resource.slug != new_slug:
+                    resource.slug = new_slug
+                    slug_changes += 1
+                    if args.dry_run:
+                        print(f'\n### Would save new slug "{new_slug}"{force_slug_note} (dry-run) ###', '\n')
+                    else:
+                        print(f'\n### Saving new slug "{new_slug}"{force_slug_note} ###', '\n')
+                        try:
+                            resource.save('slug')
+                        except Exception as e:
+                            # Slug is unique, so if it already exists, we get an error.
+                            print(f'Error: {e}')
             else:
                 print(f'Error: Unrecognized slug pattern or categories to infer resource slug from.')
 
         else:
+            skipped_resources += 1
             print(f'Skipping: "{resource.name}" because it seems to have proper attributes')
+
+    # Print summary
+    print('\n' + '=' * 50)
+    print('SUMMARY')
+    print('=' * 50)
+    print(f'Release: {release}')
+    print(f'Project: {project_slug}')
+    print(f'Mode: {"Dry-run" if args.dry_run else "Live changes"}')
+    print(f'Name changes: {name_changes}')
+    print(f'Slug changes: {slug_changes}')
+    print(f'Skipped resources: {skipped_resources}')
+    print(f'Total resources processed: {name_changes + slug_changes + skipped_resources}')
 
 
 if __name__ == '__main__':
-    main(sys.argv[1:])
+    main()

--- a/scripts/tests/test_fix_transifex_resource_names.py
+++ b/scripts/tests/test_fix_transifex_resource_names.py
@@ -2,50 +2,137 @@
 Tests for fix_transifex_resource_names.py.
 """
 
-from unittest.mock import MagicMock
-from ..fix_transifex_resource_names import get_repo_slug_from_resource
+from dataclasses import dataclass
+import pytest
+from typing import List
+
+from ..fix_transifex_resource_names import (
+    get_repo_name_from_resource,
+    get_repo_slug_from_resource,
+    parse_arguments,
+)
+
+
+@dataclass
+class ParsedArgumentsMock:
+    force_suffix: bool = False
+    dry_run: bool = False
+    release: str = 'main'
+
+
+@dataclass
+class Resource:
+    slug: str
+    name: str
+    categories: List[str]
+
+
+@pytest.fixture(autouse=True)
+def mock_random_choice(monkeypatch):
+    monkeypatch.setattr('random.choice', lambda x: '9')
 
 
 def test_get_repo_slug_from_resource_with_no_categories():
-    resource = MagicMock()
-    resource.slug = 'translations-my-xblock-conf-locale-en-lc-messages-django-po--main'
-    resource.categories = []
-    assert get_repo_slug_from_resource(resource) == 'my-xblock'
+    resource = Resource(
+        slug='translations-my-xblock-conf-locale-en-lc-messages-django-po--main',
+        name='',
+        categories=[]
+    )
+    assert get_repo_slug_from_resource(resource, 'main') == 'my-xblock-main-r9999'
 
 
 def test_get_repo_slug_from_resource_slug_js_with_no_categories():
-    resource = MagicMock()
-    resource.slug = 'translations-my-xblock-conf-locale-en-lc-messages-djangojs-po--main'
-    resource.categories = []
-    assert get_repo_slug_from_resource(resource) == 'my-xblock-js'
+    resource = Resource(
+        slug='translations-my-xblock-conf-locale-en-lc-messages-djangojs-po--main',
+        name='',
+        categories=[]
+    )
+    assert get_repo_slug_from_resource(resource, 'main') == 'my-xblock-js-main-r9999'
 
 
 def test_get_repo_name_from_invalid_slug():
-    resource = MagicMock()
-    resource.slug = 'some-gibberish-slug'
-    resource.categories = []
-    assert get_repo_slug_from_resource(resource) == None
+    resource = Resource(
+        slug='some-gibberish-slug',
+        name='',
+        categories=[]
+    )
+    assert get_repo_name_from_resource(resource) == None
 
 
 def test_get_repo_name_from_slug_and_categories():
     """
     Categories takes precedence over slug.
     """
-    resource = MagicMock()
-    resource.slug = 'translations-my-xblock1-conf-locale-en-lc-messages-django-po--main'
-    resource.categories = ['github#repository:openedx/openedx-translations#branch:main#path:translations/my-xblock2/openassessment/conf/locale/en/LC_MESSAGES/django.po']  # noqa
-    assert get_repo_slug_from_resource(resource) == 'my-xblock2'
+    resource = Resource(
+        slug='translations-my-xblock1-conf-locale-en-lc-messages-django-po--main',
+        name='',
+        categories=[
+            'github#repository:openedx/openedx-translations#branch:main#path:translations/my-xblock2/openassessment/conf/locale/en/LC_MESSAGES/django.po', # noqa
+        ]
+    )
+    assert get_repo_name_from_resource(resource) == 'my-xblock2'
 
 
 def test_get_repo_name_from_categories():
-    resource = MagicMock()
-    resource.slug = 'some-gibberish-slug'
-    resource.categories = ['github#repository:openedx/openedx-translations#branch:main#path:translations/my-xblock2/openassessment/conf/locale/en/LC_MESSAGES/django.po']  # noqa
-    assert get_repo_slug_from_resource(resource) == 'my-xblock2'
+    resource = Resource(
+        slug='some-gibberish-slug',
+        name='',
+        categories=[
+            'github#repository:openedx/openedx-translations#branch:main#path:translations/my-xblock2/openassessment/conf/locale/en/LC_MESSAGES/django.po', # noqa
+        ]
+    )
+    assert get_repo_name_from_resource(resource) == 'my-xblock2'
 
 
 def test_get_repo_name_from_categories_with_js():
-    resource = MagicMock()
-    resource.slug = 'some-gibberish-slug'
-    resource.categories = ['github#repository:openedx/openedx-translations#branch:main#path:translations/my-xblock2/openassessment/conf/locale/en/LC_MESSAGES/djangojs.po']  # noqa
-    assert get_repo_slug_from_resource(resource) == 'my-xblock2-js'
+    resource = Resource(
+        slug='some-gibberish-slug',
+        name='',
+        categories=[
+            'github#repository:openedx/openedx-translations#branch:main#path:translations/my-xblock2/openassessment/conf/locale/en/LC_MESSAGES/djangojs.po', # noqa
+        ]
+    )
+    assert get_repo_name_from_resource(resource) == 'my-xblock2-js'
+
+
+def test_get_repo_slug_from_resource_with_existing_suffix():
+    resource = Resource(
+        slug='my-resource-r1234',
+        name='my-resource-r1234',
+        categories=[]
+    )
+    # Should keep the existing suffix without adding a new one
+    assert get_repo_slug_from_resource(resource, 'main') == 'my-resource-r1234'
+
+
+def test_get_repo_slug_from_resource_with_clean_name():
+    resource = Resource(
+        slug='clean-name',
+        name='clean-name',
+        categories=[]
+    )
+    result = get_repo_slug_from_resource(resource, 'main')
+    # Should add unique suffix to clean names
+    assert result == 'clean-name-main-r9999'
+
+
+def test_parse_arguments(monkeypatch):
+    test_args = [
+        '--release', 'redwood',
+        '--dry-run',
+        '--force-suffix'
+    ]
+    monkeypatch.setattr('sys.argv', ['test_script.py'] + test_args)
+    args = parse_arguments()
+    assert args.release == 'redwood'
+    assert args.dry_run is True
+    assert args.force_suffix is True
+
+
+def test_parse_arguments_minimal(monkeypatch):
+    test_args = ['--release', 'main']
+    monkeypatch.setattr('sys.argv', ['test_script.py'] + test_args)
+    args = parse_arguments()
+    assert args.release == 'main'
+    assert args.dry_run is False
+    assert args.force_suffix is False


### PR DESCRIPTION
## Summary

Use release name as a suffix in resource names as a workaround for the branch name duplication issue:
 -  #41695


## Random Suffix `{release}-r{random_numbers}`
A random suffix is used e.g. `r3231` to denote that this is a unique slug to avoid adding needless suffix after multiple runs. The script should be safe to run multiple times.

The suffix is also useful just in case we had a resource that collides with a release name e.g. `github.com/openedx/xblock-redwood.git` which would be misclassified as a unique slug even though the name is actually reused across projects.

This sort of naunce that might save a day or two in debugging.

##  Changes:

  GitHub Workflow:
  - Changed input parameter from transifex_project_slug to release_name
  - Used default maigc value of `main`
  - Changed environment variable from TRANSIFEX_PROJECT_SLUG to RELEASE (a transparent change to most)
  
  Script (scripts/fix_transifex_resource_names.py):
  - Changed CLI argument from --tx-project-slug to --release
  - Added execution summary showing counts of name changes, slug changes, and skipped resources
  
  Tests (scripts/tests/test_fix_transifex_resource_names.py):
  - Replaced MagicMock with Resource dataclass to avoid suprises with the Mock
  - Fixed test expectations to account for release names in generated slugs