### PR TITLE
chore: add xblocks-contrib to translation extraction pipeline

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -59,6 +59,7 @@ jobs:
               'xblock-qualtrics-survey',
               'xblock-sql-grader',
               'xblock-submit-and-compare',
+              'xblocks-contrib',
             ];
 
             const allJavascriptRepos = [
@@ -271,6 +272,16 @@ jobs:
         run: |
           cd translations/${{ matrix.repo }}
           django-admin compilemessages --locale en
+
+      - name: clean up xblocks-contrib per-xblock locale directories
+        if: matrix.repo == 'xblocks-contrib'
+        run: |
+          # xblocks-contrib has per-xblock conf/locale directories for local development.
+          # make extract_translations merges all of them into a single combined file at
+          # xblocks_contrib/conf/locale/en/LC_MESSAGES/django.po for this pipeline.
+          # Remove the per-xblock locale dirs so the workflow finds only the combined one.
+          cd translations/${{ matrix.repo }}
+          find xblocks_contrib -mindepth 2 -maxdepth 3 -type d -name 'conf' -exec rm -rf {} + 2>/dev/null || true
 
       # Preparations so git adds only the translation source files, found in conf/locale/en
       - name: find the location of the translation source files

--- a/transifex.yml
+++ b/transifex.yml
@@ -376,6 +376,15 @@ git:
     mode: onlyreviewed
     translation_files_expression: 'translations/tutor-contrib-aspects/tutoraspects/templates/aspects/apps/superset/conf/locale/<lang>/locale.yaml'
 
+  # xblocks-contrib
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/xblocks-contrib/xblocks_contrib/conf/locale/en/
+    mode: onlyreviewed
+    translation_files_expression: 'translations/xblocks-contrib/xblocks_contrib/conf/locale/<lang>/'
+
   # xblock-drag-and-drop-v2
   - filter_type: dir
     file_format: PO


### PR DESCRIPTION
- Add `xblocks-contrib` to the `allPythonRepos` matrix in the extraction
    workflow.                                                                                                                       
- Add a post-extraction cleanup step that removes per-xblock `conf/locale`
  directories so the workflow finds only the single combined                                                                      
  `xblocks_contrib/conf/locale/en/LC_MESSAGES/django.po` produced by                                                              
  `make extract_translations`.                                      
- Add `xblocks-contrib` entry to `transifex.yml` mapping                                                                          
  `translations/xblocks-contrib/xblocks_contrib/conf/locale/` to Transifex.
                                                                                                                                    
  Depends on: https://github.com/openedx/xblocks-contrib/pull/236
                                                                                                                                    
  ## Testing                                                                                                                        
                                                            
  - The xblocks-contrib `make extract_translations` produces a combined
    `django.po` at the expected path.                                                                                               
  - After the cleanup step, `find` locates exactly one `conf/locale/en`
    directory and the `django.po` file within it.