### PR TITLE
chore: add xblocks-extra to translation extraction pipeline

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -59,6 +59,7 @@ jobs:
               'xblock-qualtrics-survey',
               'xblock-sql-grader',
               'xblock-submit-and-compare',
+              'xblocks-extra',
             ];
 
             const allJavascriptRepos = [
@@ -271,6 +272,14 @@ jobs:
         run: |
           cd translations/${{ matrix.repo }}
           django-admin compilemessages --locale en
+
+      # For multi-xblock repos, remove per-xblock locale directories so only the
+      # combined conf/locale/en remains (OEP-58 expects exactly one per repo).
+      - name: clean up xblocks-extra per-xblock locale directories
+        if: matrix.repo == 'xblocks-extra'
+        run: |
+          cd translations/${{ matrix.repo }}
+          find src -mindepth 2 -maxdepth 3 -type d -name 'conf' -exec rm -rf {} + 2>/dev/null || true
 
       # Preparations so git adds only the translation source files, found in conf/locale/en
       - name: find the location of the translation source files

--- a/transifex.yml
+++ b/transifex.yml
@@ -456,3 +456,12 @@ git:
     source_file_dir: translations/xblock-lti-consumer/lti_consumer/conf/locale/en/
     mode: onlyreviewed
     translation_files_expression: 'translations/xblock-lti-consumer/lti_consumer/conf/locale/<lang>/'
+
+  # xblocks-extra
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/xblocks-extra/conf/locale/en/
+    mode: onlyreviewed
+    translation_files_expression: 'translations/xblocks-extra/conf/locale/<lang>/'


### PR DESCRIPTION
Add xblocks-extra to the `allPythonRepos` matrix in the extraction workflow.

Related to https://github.com/openedx/xblocks-extra/pull/28