### PR TITLE
Adds support of monorepo python repositories for the translation extraction

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -425,43 +425,30 @@ jobs:
           rm -rf .git
           # Find all conf/locale/en directories, excluding hidden dirs and src/ subdirectories.
           # src/ dirs are source code inputs; the Makefile copies output to root-level package dirs.
-          total_status=0
-          while IFS= read -r dir; do
-            DJANGO_PATH=$(find "$dir" -name 'django.po')
-            DJANGOJS_PATH=$(find "$dir" -name 'djangojs.po')
-            ############## Special support for XBlocks
-            # if both files are not found, then it can be an XBlock (thus, text.po and textjs.po files)
-            if [ -z "$DJANGO_PATH" ] && [ -z "$DJANGOJS_PATH" ]; then
-              DJANGO_PATH=$(find "$dir" -name 'text.po')
-              DJANGOJS_PATH=$(find "$dir" -name 'textjs.po')
-              # Rename the files to django.po and djangojs.po, if exists
-              if [ -n "$DJANGO_PATH" ]; then
-                mv "$DJANGO_PATH" "$(dirname "$DJANGO_PATH")/django.po"
-                DJANGO_PATH="$(dirname "$DJANGO_PATH")/django.po"
-              fi
-              if [ -n "$DJANGOJS_PATH" ]; then
-                mv "$DJANGOJS_PATH" "$(dirname "$DJANGOJS_PATH")/djangojs.po"
-                DJANGOJS_PATH="$(dirname "$DJANGOJS_PATH")/djangojs.po"
-              fi
-            fi
-            ############## End of - Special support for XBlocks
-            paths=()
-            if [ -n "$DJANGO_PATH" ]; then
-              git add "$DJANGO_PATH" -f -v
-              paths+=("$DJANGO_PATH")
-            fi
-            if [ -n "$DJANGOJS_PATH" ]; then
-              git add "$DJANGOJS_PATH" -f -v
-              paths+=("$DJANGOJS_PATH")
-            fi
-            if [ ${#paths[@]} -gt 0 ]; then
-              dir_status=$(git status --short -- "${paths[@]}" 2>/dev/null | wc -l)
-            else
-              dir_status=0
-            fi
-            total_status=$((total_status + dir_status))
-          done < <(find . -type d -not -path '*/.*' -not -path '*/src/*' -regex ".+conf\/locale\/en$")
-          echo "GIT_STATUS=$total_status" >> $GITHUB_ENV
+          find . -type d -not -path '*/.*' -not -path '*/src/*' -regex ".+conf\/locale\/en$" \
+            | while IFS= read -r dir; do
+                DJANGO_PATH=$(find "$dir" -name 'django.po')
+                DJANGOJS_PATH=$(find "$dir" -name 'djangojs.po')
+                ############## Special support for XBlocks
+                # if both files are not found, then it can be an XBlock (thus, text.po and textjs.po files)
+                if [ -z "$DJANGO_PATH" ] && [ -z "$DJANGOJS_PATH" ]; then
+                  DJANGO_PATH=$(find "$dir" -name 'text.po')
+                  DJANGOJS_PATH=$(find "$dir" -name 'textjs.po')
+                  # Rename the files to django.po and djangojs.po, if exists
+                  if [ -n "$DJANGO_PATH" ]; then
+                    mv "$DJANGO_PATH" "$(dirname "$DJANGO_PATH")/django.po"
+                    DJANGO_PATH="$(dirname "$DJANGO_PATH")/django.po"
+                  fi
+                  if [ -n "$DJANGOJS_PATH" ]; then
+                    mv "$DJANGOJS_PATH" "$(dirname "$DJANGOJS_PATH")/djangojs.po"
+                    DJANGOJS_PATH="$(dirname "$DJANGOJS_PATH")/djangojs.po"
+                  fi
+                fi
+                ############## End of - Special support for XBlocks
+                [ -n "$DJANGO_PATH" ]   && git add "$DJANGO_PATH"   -f -v
+                [ -n "$DJANGOJS_PATH" ] && git add "$DJANGOJS_PATH" -f -v
+              done
+          echo "GIT_STATUS=$(git diff --cached --name-only | wc -l)" >> $GITHUB_ENV
 
       # Attempts to commit the translation source files if there is a difference
       - name: git commit the translation source files

--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -62,7 +62,7 @@ jobs:
             ];
 
             // Repos that contain multiple conf/locale/en directories (one per sub-package).
-            const allPythonMonoRepos = [
+            const allPythonMonorepos = [
               'xblocks-extra',
             ];
 
@@ -131,7 +131,7 @@ jobs:
 
             if (selectedRepo === '') {
               core.setOutput('pythonRepos', allPythonRepos);
-              core.setOutput('pythonMonoRepos', allPythonMonoRepos);
+              core.setOutput('pythonMonoRepos', allPythonMonorepos);
               core.setOutput('javascriptRepos', allJavascriptRepos);
               core.setOutput('dualMFEAndBaseJavascriptRepos', allDualMFEAndBaseJavascriptRepos);
               core.setOutput('genericRepos', allGenericRepos);
@@ -145,7 +145,7 @@ jobs:
               core.setOutput('hasPythonRepos', false);
             }
 
-            if (allPythonMonoRepos.includes(selectedRepo)) {
+            if (allPythonMonorepos.includes(selectedRepo)) {
               core.setOutput('pythonMonoRepos', [selectedRepo]);
             } else {
               core.setOutput('pythonMonoRepos', []);
@@ -353,11 +353,12 @@ jobs:
           # push changes to branch
           git push
 
-  python-mono-translations:
+  python-monorepo-translations:
     # Handles repos with multiple conf/locale/en directories (one per sub-package), e.g. xblocks-extra.
     if: ${{ !cancelled() && fromJson(needs.setup-matrix.outputs.has_python_mono_repos) == true }}
     needs: [setup-branch, setup-matrix, python-translations]
     strategy:
+      # using max-parallel to avoid git push/pull issues when running in parallel
       max-parallel: 1
       matrix:
         repo: ${{ fromJson(needs.setup-matrix.outputs.python_mono_repos) }}
@@ -366,24 +367,17 @@ jobs:
     continue-on-error: true
 
     steps:
+      # Clones the openedx-translations repo
       - name: clone openedx/openedx-translations
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.setup-branch.outputs.branch }}
 
-      - name: setup python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-          cache: pip
-          cache-dependency-path: requirements/translations.txt
-
-      - name: install requirements
-        run: pip install -r requirements/translations.txt
-
+      # Installs gettext, a dependency for extracting translation source files in django
       - name: install gettext
         run: sudo apt install -y gettext
 
+      # Clones the  repository
       - name: clone ${{ github.repository_owner }}/${{ matrix.repo }}
         uses: actions/checkout@v6
         with:
@@ -391,6 +385,20 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
           path: translations/${{ matrix.repo }}
 
+      # Setup Python
+      - name: setup python
+        uses: actions/setup-python@v5
+        id: setup_python
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: requirements/translations.txt
+
+      # Installs Python requirements from translations.txt
+      - name: install requirements
+        run: pip install -r requirements/translations.txt
+
+      # Extracts the translation source files
       - name: extract translation source files
         run: |
           cd translations/${{ matrix.repo }}
@@ -398,18 +406,22 @@ jobs:
         env:
           IS_OPENEDX_TRANSLATIONS_WORKFLOW: yes
 
+      # Validate compilation of translation source files
       - name: validate compilation of translation source files
         run: |
           cd translations/${{ matrix.repo }}
           django-admin compilemessages --locale en
 
+      # Preparations so git adds only the translation source files, found in conf/locale/en
       - name: add translation source files to openedx-translations
         id: add-sources
         run: |
+          # set identity
           git config --global user.email "translations-bot@openedx.org"
           git config --global user.name "edx-transifex-bot"
+          # Change directory to translations/${{ matrix.repo }}
           cd translations/${{ matrix.repo }}
-          # remove .git so we don't commit a submodule
+          # remove translations/${{ matrix.repo }}/.git so we don't commit a submodule
           rm -rf .git
           # Find all conf/locale/en directories, excluding hidden dirs and src/ subdirectories.
           # src/ dirs are source code inputs; the Makefile copies output to root-level package dirs.
@@ -435,15 +447,18 @@ jobs:
           done < <(find . -type d -not -path '*/.*' -not -path '*/src/*' -regex ".+conf\/locale\/en$")
           echo "GIT_STATUS=$total_status" >> $GITHUB_ENV
 
+      # Attempts to commit the translation source files if there is a difference
       - name: git commit the translation source files
         if: "${{ env.GIT_STATUS > 0 }}"
         run: |
+          # commit the changes
           git commit -m "chore: add extracted translation source files from ${{ matrix.repo }}"
+          # push changes to branch
           git push
 
   js-translations:
     if: ${{ !cancelled() && fromJson(needs.setup-matrix.outputs.has_js_repos) == true }}
-    needs: [setup-branch, setup-matrix, python-translations, python-mono-translations]
+    needs: [setup-branch, setup-matrix, python-translations, python-monorepo-translations]
     strategy:
       # using max-parallel to avoid git push/pull issues when running in parallel
       max-parallel: 1
@@ -707,7 +722,7 @@ jobs:
 
   merge-translations:
     runs-on: ubuntu-latest
-    needs: [setup-branch, python-translations, python-mono-translations, js-translations, generic-translations]
+    needs: [setup-branch, python-translations, python-monorepo-translations, js-translations, generic-translations]
 
     steps:
       # Clones the openedx-translations repo on the automated/extract-translation-source-files-# branch

--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -417,9 +417,20 @@ jobs:
           while IFS= read -r dir; do
             DJANGO_PATH=$(find "$dir" -name 'django.po')
             DJANGOJS_PATH=$(find "$dir" -name 'djangojs.po')
-            [ -n "$DJANGO_PATH" ] && git add "$DJANGO_PATH" -f -v
-            [ -n "$DJANGOJS_PATH" ] && git add "$DJANGOJS_PATH" -f -v
-            dir_status=$(git status $DJANGO_PATH $DJANGOJS_PATH -s 2>/dev/null | wc -l)
+            paths=()
+            if [ -n "$DJANGO_PATH" ]; then
+              git add "$DJANGO_PATH" -f -v
+              paths+=("$DJANGO_PATH")
+            fi
+            if [ -n "$DJANGOJS_PATH" ]; then
+              git add "$DJANGOJS_PATH" -f -v
+              paths+=("$DJANGOJS_PATH")
+            fi
+            if [ ${#paths[@]} -gt 0 ]; then
+              dir_status=$(git status --short -- "${paths[@]}" 2>/dev/null | wc -l)
+            else
+              dir_status=0
+            fi
             total_status=$((total_status + dir_status))
           done < <(find . -type d -not -path '*/.*' -not -path '*/src/*' -regex ".+conf\/locale\/en$")
           echo "GIT_STATUS=$total_status" >> $GITHUB_ENV

--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -429,6 +429,22 @@ jobs:
           while IFS= read -r dir; do
             DJANGO_PATH=$(find "$dir" -name 'django.po')
             DJANGOJS_PATH=$(find "$dir" -name 'djangojs.po')
+            ############## Special support for XBlocks
+            # if both files are not found, then it can be an XBlock (thus, text.po and textjs.po files)
+            if [ -z "$DJANGO_PATH" ] && [ -z "$DJANGOJS_PATH" ]; then
+              DJANGO_PATH=$(find "$dir" -name 'text.po')
+              DJANGOJS_PATH=$(find "$dir" -name 'textjs.po')
+              # Rename the files to django.po and djangojs.po, if exists
+              if [ -n "$DJANGO_PATH" ]; then
+                mv "$DJANGO_PATH" "$(dirname "$DJANGO_PATH")/django.po"
+                DJANGO_PATH="$(dirname "$DJANGO_PATH")/django.po"
+              fi
+              if [ -n "$DJANGOJS_PATH" ]; then
+                mv "$DJANGOJS_PATH" "$(dirname "$DJANGOJS_PATH")/djangojs.po"
+                DJANGOJS_PATH="$(dirname "$DJANGOJS_PATH")/djangojs.po"
+              fi
+            fi
+            ############## End of - Special support for XBlocks
             paths=()
             if [ -n "$DJANGO_PATH" ]; then
               git add "$DJANGO_PATH" -f -v

--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -124,14 +124,14 @@ jobs:
             }
 
             core.setOutput('hasPythonRepos', true);
-            core.setOutput('hasPythonMonoRepos', true);
+            core.setOutput('hasPythonMonorepos', true);
             core.setOutput('hasJavascriptRepos', true);
             core.setOutput('hasDualMFEAndBaseJavascriptRepos', true);
             core.setOutput('hasGenericRepos', true);
 
             if (selectedRepo === '') {
               core.setOutput('pythonRepos', allPythonRepos);
-              core.setOutput('pythonMonoRepos', allPythonMonorepos);
+              core.setOutput('pythonMonorepos', allPythonMonorepos);
               core.setOutput('javascriptRepos', allJavascriptRepos);
               core.setOutput('dualMFEAndBaseJavascriptRepos', allDualMFEAndBaseJavascriptRepos);
               core.setOutput('genericRepos', allGenericRepos);
@@ -146,10 +146,10 @@ jobs:
             }
 
             if (allPythonMonorepos.includes(selectedRepo)) {
-              core.setOutput('pythonMonoRepos', [selectedRepo]);
+              core.setOutput('pythonMonorepos', [selectedRepo]);
             } else {
-              core.setOutput('pythonMonoRepos', []);
-              core.setOutput('hasPythonMonoRepos', false);
+              core.setOutput('pythonMonorepos', []);
+              core.setOutput('hasPythonMonorepos', false);
             }
 
             if (allJavascriptRepos.includes(selectedRepo)) {
@@ -177,8 +177,8 @@ jobs:
     outputs:
       has_python_repos: ${{ steps.generate_repo_matrix.outputs.hasPythonRepos }}
       python_repos: ${{ steps.generate_repo_matrix.outputs.pythonRepos }}
-      has_python_mono_repos: ${{ steps.generate_repo_matrix.outputs.hasPythonMonoRepos }}
-      python_mono_repos: ${{ steps.generate_repo_matrix.outputs.pythonMonoRepos }}
+      has_python_monorepos: ${{ steps.generate_repo_matrix.outputs.hasPythonMonorepos }}
+      python_monorepos: ${{ steps.generate_repo_matrix.outputs.pythonMonorepos }}
       has_js_repos: ${{ steps.generate_repo_matrix.outputs.hasJavascriptRepos }}
       js_repos: ${{ steps.generate_repo_matrix.outputs.javascriptRepos }}
       has_dual_js_repos: ${{ steps.generate_repo_matrix.outputs.hasDualMFEAndBaseJavascriptRepos }}
@@ -355,13 +355,13 @@ jobs:
 
   python-monorepo-translations:
     # Handles repos with multiple conf/locale/en directories (one per sub-package), e.g. xblocks-extra.
-    if: ${{ !cancelled() && fromJson(needs.setup-matrix.outputs.has_python_mono_repos) == true }}
+    if: ${{ !cancelled() && fromJson(needs.setup-matrix.outputs.has_python_monorepos) == true }}
     needs: [setup-branch, setup-matrix, python-translations]
     strategy:
       # using max-parallel to avoid git push/pull issues when running in parallel
       max-parallel: 1
       matrix:
-        repo: ${{ fromJson(needs.setup-matrix.outputs.python_mono_repos) }}
+        repo: ${{ fromJson(needs.setup-matrix.outputs.python_monorepos) }}
 
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -61,6 +61,11 @@ jobs:
               'xblock-submit-and-compare',
             ];
 
+            // Repos that contain multiple conf/locale/en directories (one per sub-package).
+            const allPythonMonoRepos = [
+              'xblocks-extra',
+            ];
+
             const allJavascriptRepos = [
               'frontend-app-admin-portal',
               'frontend-app-publisher',
@@ -119,12 +124,14 @@ jobs:
             }
 
             core.setOutput('hasPythonRepos', true);
+            core.setOutput('hasPythonMonoRepos', true);
             core.setOutput('hasJavascriptRepos', true);
             core.setOutput('hasDualMFEAndBaseJavascriptRepos', true);
             core.setOutput('hasGenericRepos', true);
 
             if (selectedRepo === '') {
               core.setOutput('pythonRepos', allPythonRepos);
+              core.setOutput('pythonMonoRepos', allPythonMonoRepos);
               core.setOutput('javascriptRepos', allJavascriptRepos);
               core.setOutput('dualMFEAndBaseJavascriptRepos', allDualMFEAndBaseJavascriptRepos);
               core.setOutput('genericRepos', allGenericRepos);
@@ -136,6 +143,13 @@ jobs:
             } else {
               core.setOutput('pythonRepos', []);
               core.setOutput('hasPythonRepos', false);
+            }
+
+            if (allPythonMonoRepos.includes(selectedRepo)) {
+              core.setOutput('pythonMonoRepos', [selectedRepo]);
+            } else {
+              core.setOutput('pythonMonoRepos', []);
+              core.setOutput('hasPythonMonoRepos', false);
             }
 
             if (allJavascriptRepos.includes(selectedRepo)) {
@@ -163,6 +177,8 @@ jobs:
     outputs:
       has_python_repos: ${{ steps.generate_repo_matrix.outputs.hasPythonRepos }}
       python_repos: ${{ steps.generate_repo_matrix.outputs.pythonRepos }}
+      has_python_mono_repos: ${{ steps.generate_repo_matrix.outputs.hasPythonMonoRepos }}
+      python_mono_repos: ${{ steps.generate_repo_matrix.outputs.pythonMonoRepos }}
       has_js_repos: ${{ steps.generate_repo_matrix.outputs.hasJavascriptRepos }}
       js_repos: ${{ steps.generate_repo_matrix.outputs.javascriptRepos }}
       has_dual_js_repos: ${{ steps.generate_repo_matrix.outputs.hasDualMFEAndBaseJavascriptRepos }}
@@ -337,9 +353,86 @@ jobs:
           # push changes to branch
           git push
 
+  python-mono-translations:
+    # Handles repos with multiple conf/locale/en directories (one per sub-package), e.g. xblocks-extra.
+    if: ${{ !cancelled() && fromJson(needs.setup-matrix.outputs.has_python_mono_repos) == true }}
+    needs: [setup-branch, setup-matrix, python-translations]
+    strategy:
+      max-parallel: 1
+      matrix:
+        repo: ${{ fromJson(needs.setup-matrix.outputs.python_mono_repos) }}
+
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: clone openedx/openedx-translations
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.setup-branch.outputs.branch }}
+
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: requirements/translations.txt
+
+      - name: install requirements
+        run: pip install -r requirements/translations.txt
+
+      - name: install gettext
+        run: sudo apt install -y gettext
+
+      - name: clone ${{ github.repository_owner }}/${{ matrix.repo }}
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.repository_owner }}/${{ matrix.repo }}
+          ref: ${{ github.event.inputs.ref }}
+          path: translations/${{ matrix.repo }}
+
+      - name: extract translation source files
+        run: |
+          cd translations/${{ matrix.repo }}
+          make extract_translations
+        env:
+          IS_OPENEDX_TRANSLATIONS_WORKFLOW: yes
+
+      - name: validate compilation of translation source files
+        run: |
+          cd translations/${{ matrix.repo }}
+          django-admin compilemessages --locale en
+
+      - name: add translation source files to openedx-translations
+        id: add-sources
+        run: |
+          git config --global user.email "translations-bot@openedx.org"
+          git config --global user.name "edx-transifex-bot"
+          cd translations/${{ matrix.repo }}
+          # remove .git so we don't commit a submodule
+          rm -rf .git
+          # Find all conf/locale/en directories, excluding hidden dirs and src/ subdirectories.
+          # src/ dirs are source code inputs; the Makefile copies output to root-level package dirs.
+          total_status=0
+          while IFS= read -r dir; do
+            DJANGO_PATH=$(find "$dir" -name 'django.po')
+            DJANGOJS_PATH=$(find "$dir" -name 'djangojs.po')
+            [ -n "$DJANGO_PATH" ] && git add "$DJANGO_PATH" -f -v
+            [ -n "$DJANGOJS_PATH" ] && git add "$DJANGOJS_PATH" -f -v
+            dir_status=$(git status $DJANGO_PATH $DJANGOJS_PATH -s 2>/dev/null | wc -l)
+            total_status=$((total_status + dir_status))
+          done < <(find . -type d -not -path '*/.*' -not -path '*/src/*' -regex ".+conf\/locale\/en$")
+          echo "GIT_STATUS=$total_status" >> $GITHUB_ENV
+
+      - name: git commit the translation source files
+        if: "${{ env.GIT_STATUS > 0 }}"
+        run: |
+          git commit -m "chore: add extracted translation source files from ${{ matrix.repo }}"
+          git push
+
   js-translations:
     if: ${{ !cancelled() && fromJson(needs.setup-matrix.outputs.has_js_repos) == true }}
-    needs: [setup-branch, setup-matrix, python-translations]
+    needs: [setup-branch, setup-matrix, python-translations, python-mono-translations]
     strategy:
       # using max-parallel to avoid git push/pull issues when running in parallel
       max-parallel: 1
@@ -603,7 +696,7 @@ jobs:
 
   merge-translations:
     runs-on: ubuntu-latest
-    needs: [setup-branch, python-translations, js-translations, generic-translations]
+    needs: [setup-branch, python-translations, python-mono-translations, js-translations, generic-translations]
 
     steps:
       # Clones the openedx-translations repo on the automated/extract-translation-source-files-# branch

--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -425,29 +425,29 @@ jobs:
           rm -rf .git
           # Find all conf/locale/en directories, excluding hidden dirs and src/ subdirectories.
           # src/ dirs are source code inputs; the Makefile copies output to root-level package dirs.
-          find . -type d -not -path '*/.*' -not -path '*/src/*' -regex ".+conf\/locale\/en$" \
-            | while IFS= read -r dir; do
-                DJANGO_PATH=$(find "$dir" -name 'django.po')
-                DJANGOJS_PATH=$(find "$dir" -name 'djangojs.po')
-                ############## Special support for XBlocks
-                # if both files are not found, then it can be an XBlock (thus, text.po and textjs.po files)
-                if [ -z "$DJANGO_PATH" ] && [ -z "$DJANGOJS_PATH" ]; then
-                  DJANGO_PATH=$(find "$dir" -name 'text.po')
-                  DJANGOJS_PATH=$(find "$dir" -name 'textjs.po')
-                  # Rename the files to django.po and djangojs.po, if exists
-                  if [ -n "$DJANGO_PATH" ]; then
-                    mv "$DJANGO_PATH" "$(dirname "$DJANGO_PATH")/django.po"
-                    DJANGO_PATH="$(dirname "$DJANGO_PATH")/django.po"
-                  fi
-                  if [ -n "$DJANGOJS_PATH" ]; then
-                    mv "$DJANGOJS_PATH" "$(dirname "$DJANGOJS_PATH")/djangojs.po"
-                    DJANGOJS_PATH="$(dirname "$DJANGOJS_PATH")/djangojs.po"
-                  fi
-                fi
-                ############## End of - Special support for XBlocks
-                [ -n "$DJANGO_PATH" ]   && git add "$DJANGO_PATH"   -f -v
-                [ -n "$DJANGOJS_PATH" ] && git add "$DJANGOJS_PATH" -f -v
-              done
+          mapfile -t dirs < <(find . -type d -not -path '*/.*' -not -path '*/src/*' -regex ".+conf\/locale\/en$")
+          for dir in "${dirs[@]}"; do
+            DJANGO_PATH=$(find "$dir" -name 'django.po')
+            DJANGOJS_PATH=$(find "$dir" -name 'djangojs.po')
+            ############## Special support for XBlocks
+            # if both files are not found, then it can be an XBlock (thus, text.po and textjs.po files)
+            if [ -z "$DJANGO_PATH" ] && [ -z "$DJANGOJS_PATH" ]; then
+              DJANGO_PATH=$(find "$dir" -name 'text.po')
+              DJANGOJS_PATH=$(find "$dir" -name 'textjs.po')
+              # Rename the files to django.po and djangojs.po, if exists
+              if [ -n "$DJANGO_PATH" ]; then
+                mv "$DJANGO_PATH" "$(dirname "$DJANGO_PATH")/django.po"
+                DJANGO_PATH="$(dirname "$DJANGO_PATH")/django.po"
+              fi
+              if [ -n "$DJANGOJS_PATH" ]; then
+                mv "$DJANGOJS_PATH" "$(dirname "$DJANGOJS_PATH")/djangojs.po"
+                DJANGOJS_PATH="$(dirname "$DJANGOJS_PATH")/djangojs.po"
+              fi
+            fi
+            ############## End of - Special support for XBlocks
+            [ -n "$DJANGO_PATH" ]   && git add "$DJANGO_PATH"   -f -v
+            [ -n "$DJANGOJS_PATH" ] && git add "$DJANGOJS_PATH" -f -v
+          done
           echo "GIT_STATUS=$(git diff --cached --name-only | wc -l)" >> $GITHUB_ENV
 
       # Attempts to commit the translation source files if there is a difference

--- a/transifex.yml
+++ b/transifex.yml
@@ -456,3 +456,57 @@ git:
     source_file_dir: translations/xblock-lti-consumer/lti_consumer/conf/locale/en/
     mode: onlyreviewed
     translation_files_expression: 'translations/xblock-lti-consumer/lti_consumer/conf/locale/<lang>/'
+
+  # xblocks-extra/audio
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/xblocks-extra/audio/conf/locale/en/
+    mode: onlyreviewed
+    translation_files_expression: 'translations/xblocks-extra/audio/conf/locale/<lang>/'
+
+  # xblocks-extra/feedback
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/xblocks-extra/feedback/conf/locale/en/
+    mode: onlyreviewed
+    translation_files_expression: 'translations/xblocks-extra/feedback/conf/locale/<lang>/'
+
+  # xblocks-extra/imagemodal
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/xblocks-extra/imagemodal/conf/locale/en/
+    mode: onlyreviewed
+    translation_files_expression: 'translations/xblocks-extra/imagemodal/conf/locale/<lang>/'
+
+  # xblocks-extra/qualtricssurvey
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/xblocks-extra/qualtricssurvey/conf/locale/en/
+    mode: onlyreviewed
+    translation_files_expression: 'translations/xblocks-extra/qualtricssurvey/conf/locale/<lang>/'
+
+  # xblocks-extra/sql_grader
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/xblocks-extra/sql_grader/conf/locale/en/
+    mode: onlyreviewed
+    translation_files_expression: 'translations/xblocks-extra/sql_grader/conf/locale/<lang>/'
+
+  # xblocks-extra/submit_and_compare
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/xblocks-extra/submit_and_compare/conf/locale/en/
+    mode: onlyreviewed
+    translation_files_expression: 'translations/xblocks-extra/submit_and_compare/conf/locale/<lang>/'


### PR DESCRIPTION
Parent ticket: https://github.com/openedx/xblocks-contrib/issues/241
Relevant xblocks-extra PR: https://github.com/openedx/xblocks-extra/pull/35

## Details:
                                                                                     
 xblocks-extra is a mono-repo consolidating multiple XBlocks, so it has one      
  conf/locale/en/ per sub-package instead of a single top-level one. The existing    
  python-translations job assumes a single locale directory and can't handle this
  layout.                                                                            
                                                                                   
  This PR adds:                       
  - A new python-mono-translations job that iterates over all conf/locale/en/
  directories found in the repo (excluding src/ subdirectories which are source
  inputs, not extraction outputs).                                             
  - allPythonMonoRepos matrix list in setup-matrix to support targeting these repos
  selectively via workflow_dispatch.                                               
  - Transifex config entries in transifex.yml for the 6 sub-packages: audio,         
  feedback, imagemodal, qualtricssurvey, sql_grader, submit_and_compare.    
                                                                                     
  The extracted translation file paths follow the same                             
```translations/<repo>/<module>/conf/locale/<lang>/```
 structure used by the openedx-platform translations lookup implementation, ensuring full compatibility.

## Testing Notes:
This PR has been testing on the [forked repository](https://github.com/farhan/openedx-translations).

### Here are the test runners:

**Test branch on `farhan/openedx-translations`** 

- Test branch: `farhan/test-branch`
- Test PR of this branch: https://github.com/farhan/openedx-translations/pull/2

#### Later runs after bef08bcc360e53354db888f52a4ab136dc2ccc94 commit:

Run extract translations on `xblocks-extra` repository: https://github.com/farhan/openedx-translations/actions/runs/25792200061
Run extract translations on all the repositories: https://github.com/farhan/openedx-translations/actions/runs/25792210572/job/75760389645
Commits generated by complete runner: https://github.com/farhan/openedx-translations/compare/farhan/test-branch...farhan:openedx-translations:automated/extract-translation-source-files-20260513T100301

#### Older runs:

~~Run extract translations on `xblocks-extra` repository: https://github.com/farhan/openedx-translations/actions/runs/25718274740
Run extract translations on all the repositories: https://github.com/farhan/openedx-translations/actions/runs/25718285258
Run extract translations on `xblocks-extra` repository: https://github.com/farhan/openedx-translations/actions/runs/25596042310/job/75142053733
Run extract translations on all the repositories: https://github.com/farhan/openedx-translations/actions/runs/25596220624/job/75145189672~~


## Followup PR:
Extract shared Python setup steps into a composite action
https://github.com/farhan/openedx-translations/pull/3

