### PR TITLE
feat: add xblocks-extra/freetextresponse to translations pipeline

### DIFF
--- a/transifex.yml
+++ b/transifex.yml
@@ -475,6 +475,15 @@ git:
     mode: onlyreviewed
     translation_files_expression: 'translations/xblocks-extra/feedback/conf/locale/<lang>/'
 
+  # xblocks-extra/freetextresponse
+  - filter_type: dir
+    file_format: PO
+    source_file_extension: po
+    source_language: en
+    source_file_dir: translations/xblocks-extra/freetextresponse/conf/locale/en/
+    mode: onlyreviewed
+    translation_files_expression: 'translations/xblocks-extra/freetextresponse/conf/locale/<lang>/'
+
   # xblocks-extra/imagemodal
   - filter_type: dir
     file_format: PO


### PR DESCRIPTION
## Summary

- Adds `freetextresponse` to the `transifex.yml` pipeline under the `xblocks-extra` monorepo group
- Inserted alphabetically between `xblocks-extra/feedback` and `xblocks-extra/imagemodal`
- The xblock was migrated from the standalone `xblock-free-text-response` package into `xblocks-extra` (openedx/xblocks-extra#36); this entry supersedes the existing `xblock-free-text-response/freetextresponse` entry (line 393)
- The companion PR that adds `.tx/config` to xblocks-extra: openedx/xblocks-extra#45
- `xblocks-extra` is already listed in `allPythonMonorepos` in `extract-translation-source-files.yml` (added in #72135), so no workflow changes are needed

Closes openedx/xblocks-extra#41

## Merge sequence

1. Merge openedx/xblocks-extra#45 — triggers extraction run, populates `translations/xblocks-extra/freetextresponse/`
2. **Merge this PR (#74373)** — adds `transifex.yml` entry for `xblocks-extra/freetextresponse`
3. Verify openedx/xblocks-extra#42 — confirm new path has ≥ 37 locales (matches legacy `xblock-free-text-response` coverage)
4. Merge #74375 — removes legacy `xblock-free-text-response` entries (resolves openedx/xblocks-extra#43)
5. openedx/xblocks-extra#44 — manual LMS validation: run `make pull_xblock_translations` in `lms-shell` and confirm translated UI renders correctly

## Test plan

- [ ] `extract-translation-source-files` workflow validates this entry after the xblocks-extra PR merges and a translation extraction run picks up `freetextresponse/conf/locale/en/LC_MESSAGES/django.po`

🤖 Generated with [Claude Code](https://claude.com/claude-code)